### PR TITLE
feat: add internal names to models

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,23 @@ import { Kineo } from "kineo";
 import { Neo4jAdapter } from "kineo/adapter/neo4j";
 import {
   defineSchema,
-  defineModel,
+  model,
   field,
   relation,
   type InferSchema,
 } from "kineo/schema";
 
 export const schema = defineSchema({
-  users: defineModel({
+  users: model("User", {
     name: field.string().id(),
     password: field.string().required(),
     posts: relation.to("Post").outgoing("HAS_POST").array(),
   }),
 
-  posts: defineModel({
+  posts: model("Post", {
     id: field.string().id(),
     title: field.string().required(),
-    author: relation.to("users").incoming("HAS_POST"),
+    author: relation.to("User").incoming("HAS_POST"),
   }),
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kineo",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "description": "Declarive, TypeScript-first Object-Relation/Graph Mapper (ORM/OGM).",
   "main": "./dist/client.mjs",

--- a/src/client.ts
+++ b/src/client.ts
@@ -50,7 +50,7 @@ export function Kineo<
 >(adapter: TAdapter, schema: TSchema): Kineo<TSchema, TAdapter> {
   const client: Record<string, Model<any, any>> = {};
   for (const key in schema) {
-    client[key] = new adapter.Model(schema, schema[key], adapter);
+    client[key] = new adapter.Model(schema[key].$modelName ?? key, adapter);
   }
 
   return {

--- a/src/kit/index.ts
+++ b/src/kit/index.ts
@@ -485,13 +485,13 @@ export function importPath(file: string) {
 export function ensureImports(source: string): string {
   const hasImports =
     source.includes("defineSchema") &&
-    source.includes("defineModel") &&
+    source.includes("model") &&
     source.includes("field") &&
     source.includes("relation");
 
   if (hasImports) return source;
 
-  const importLine = `import { defineSchema, defineModel, field, relation } from "kineo/schema";\n`;
+  const importLine = `import { defineSchema, model, field, relation } from "kineo/schema";\n`;
 
   // Insert before first import or at top
   if (/^import\s/m.test(source)) {
@@ -514,7 +514,7 @@ export function generateSchemaSource(
         })
         .join(",\n");
 
-      return `  ${modelName}: defineModel({\n${fields}\n  })`;
+      return `  ${modelName}: model({\n${fields}\n  })`;
     })
     .join(",\n");
 

--- a/src/kit/utils.ts
+++ b/src/kit/utils.ts
@@ -201,6 +201,8 @@ export function getDiff(prev: Schema, cur: Schema): SchemaDiff {
   for (const model of prevModels) {
     if (!cur[model]) {
       breaking.push(`Model "${model}" was removed`);
+    } else if (cur[model].$modelName !== prev[model].$modelName) {
+      breaking.push(`Model "${model}" was renamed to ${cur[model].$modelName}`);
     }
   }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -285,7 +285,6 @@ export type UpsertManyReturn<
  * A model. This is different from a model definition; the definition is just the schema, the class provides the functionality.
  */
 export class Model<S extends Schema, M extends ModelDef> {
-  // ? Not sure if these will be necessary
   /**
    * The name of the model.
    */

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { defineModel, defineSchema, field, relation } from "@/schema";
+import { model, defineSchema, field, relation } from "@/schema";
 import { Kineo, type InferClient } from "@/client";
 import { GraphModel, Model } from "@/model";
 import type { Adapter } from "@/adapter";
@@ -22,12 +22,12 @@ const adapter: Adapter<typeof GraphModel, any> = {
 };
 
 const schema = defineSchema({
-  users: defineModel({
+  users: model({
     name: field.string().id(),
     bio: field.string(),
     posts: relation.to("posts").array().default([]),
   }),
-  posts: defineModel({
+  posts: model({
     id: field.int().id(),
     created: field.datetime(),
     updated: field.timestamp(),

--- a/tests/kit/cli.test.ts
+++ b/tests/kit/cli.test.ts
@@ -121,7 +121,7 @@ describe("kineo CLI (unit)", () => {
       const src = "export const schema = defineSchema({})";
       const res = helpers.ensureImports(src);
       expect(res).toContain(
-        'import { defineSchema, defineModel, field, relation } from "kineo/schema";',
+        'import { defineSchema, model, field, relation } from "kineo/schema";',
       );
       expect(res).toContain("defineSchema");
     });
@@ -129,7 +129,7 @@ describe("kineo CLI (unit)", () => {
     test("ensureImports does not duplicate when imports are present", () => {
       if (!helpers || !helpers.ensureImports) return;
       const src =
-        'import { defineSchema, defineModel, field, relation } from "kineo/schema";\nexport const schema = defineSchema({})';
+        'import { defineSchema, model, field, relation } from "kineo/schema";\nexport const schema = defineSchema({})';
       const res = helpers.ensureImports(src);
       expect(res).toBe(src);
     });

--- a/tests/kit/index.test.ts
+++ b/tests/kit/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, vi } from "vitest";
 import { push, pull, generate, deploy, status, rollback, getDiff } from "@/kit";
 import { KineoKitError, KineoKitErrorKind } from "@/error";
-import { defineModel, defineSchema, field } from "@/schema";
+import { model, defineSchema, field } from "@/schema";
 import type { Adapter } from "@/adapter";
 
 // A minimal fake adapter
@@ -18,7 +18,7 @@ function createFakeAdapter(
 }
 
 const simpleSchema = defineSchema({
-  User: defineModel({
+  users: model("User", {
     id: field.int().required(),
   }),
 });
@@ -34,7 +34,7 @@ describe("push()", () => {
   test("throws on breaking schema diff", async () => {
     const adapter = createFakeAdapter({
       pull: vi.fn().mockResolvedValue({
-        User: defineModel({
+        User: model({
           id: field.int().id(),
           name: field.string(),
         }),
@@ -43,7 +43,7 @@ describe("push()", () => {
     });
 
     const newSchema = defineSchema({
-      User: defineModel({
+      users: model("User", {
         id: field.int().id(),
       }),
     });
@@ -84,8 +84,10 @@ describe("getDiff()", () => {
   });
 
   test("detects added and removed fields", () => {
-    const prev = defineSchema({ User: defineModel({ id: field.int() }) });
-    const cur = defineSchema({ User: defineModel({ name: field.string() }) });
+    const prev = defineSchema({ users: model("User", { id: field.int() }) });
+    const cur = defineSchema({
+      users: model("User", { name: field.string() }),
+    });
     const diff = getDiff(prev, cur);
     expect(diff.breaking[0]).toMatch(/id/);
     expect(diff.nonBreaking[0]).toMatch(/name/);

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -5,7 +5,7 @@ import {
   FieldDef,
   RelationDef,
   defineSchema,
-  defineModel,
+  model,
 } from "@/schema";
 
 describe("FieldDef", () => {
@@ -68,12 +68,13 @@ describe("RelationDef", () => {
 describe("Schema utilities", () => {
   test("defineSchema return the same schema object", () => {
     const schema = defineSchema({
-      User: defineModel({
+      users: model("User", {
         id: field.int("id").required(),
         name: field.string("name"),
       }),
     });
-    expect(schema.User.id.kind).toBe("int");
-    expect(schema.User.name.kind).toBe("string");
+    expect(schema.users.$modelName).toBe("User");
+    expect(schema.users.id.kind).toBe("int");
+    expect(schema.users.name.kind).toBe("string");
   });
 });


### PR DESCRIPTION
allow you to rename models in the db, for example:
```ts
defineSchema({
  users: model("User", {}),
});
```

for relationships, the target model must be the name of the model, not the key:
```ts
defineSchema({
  users: model("User", {}),
  posts: model("Post", {
    author: relation.to("User"), // not `users`, `User`
  }),
});
```