### PR TITLE
fix: cypher compiler didn't throw on/normalize plain objects

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,21 @@
-packages/kineo/LICENSE
+MIT License
+
+Copyright (c) 2025 trailfrost
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eslint": "^9.36.0",
     "globals": "^16.4.0",
     "prettier": "^3.6.2",
-    "turbo": "^2.6.3",
+    "turbo": "^2.7.0",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.44.0",
     "vitest": "^4.0.15"

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kineojs/better-auth",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Kineo plugin/adapter for Better-Auth.",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",

--- a/packages/better-auth/tests/adapter.test.ts
+++ b/packages/better-auth/tests/adapter.test.ts
@@ -64,13 +64,13 @@ describe("kineoAdapter", () => {
           createdAt: expect.any(Date),
           updatedAt: expect.any(Date),
         }),
-      })
+      }),
     );
 
     expect(result).toEqual(
       expect.objectContaining({
         id: "1",
-      })
+      }),
     );
   });
 
@@ -180,7 +180,7 @@ describe("kineoAdapter", () => {
             connector: "AND",
           },
         ],
-      })
+      }),
     );
 
     expect(result).toMatchObject({
@@ -203,7 +203,7 @@ describe("kineoAdapter", () => {
         model: "user",
         where: [],
         update: expect.any(Object),
-      })
+      }),
     );
 
     expect(result).toEqual(execResult.entryCount);

--- a/packages/better-auth/tests/adapter.test.ts
+++ b/packages/better-auth/tests/adapter.test.ts
@@ -64,13 +64,13 @@ describe("kineoAdapter", () => {
           createdAt: expect.any(Date),
           updatedAt: expect.any(Date),
         }),
-      }),
+      })
     );
 
     expect(result).toEqual(
       expect.objectContaining({
         id: "1",
-      }),
+      })
     );
   });
 
@@ -180,7 +180,7 @@ describe("kineoAdapter", () => {
             connector: "AND",
           },
         ],
-      }),
+      })
     );
 
     expect(result).toMatchObject({
@@ -203,15 +203,9 @@ describe("kineoAdapter", () => {
         model: "user",
         where: [],
         update: expect.any(Object),
-      }),
+      })
     );
 
     expect(result).toEqual(execResult.entryCount);
-  });
-
-  test("exposes createSchema", () => {
-    const adapter = kineoAdapter(client)({});
-    expect(adapter.createSchema).toBeDefined();
-    expect(typeof adapter.createSchema).toBe("function");
   });
 });

--- a/packages/kineo/package.json
+++ b/packages/kineo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kineo",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "type": "module",
   "description": "Declarive, TypeScript-first Object-Relation/Graph Mapper (ORM/OGM).",
   "main": "./dist/index.mjs",

--- a/packages/kineo/src/compilers/cypher.ts
+++ b/packages/kineo/src/compilers/cypher.ts
@@ -1,4 +1,5 @@
 import type { Compiler } from "@/adapter";
+import neo4j from "neo4j-driver";
 import * as IR from "@/ir";
 
 /**
@@ -98,9 +99,13 @@ function propsToCypher(
   return entries.length ? `{ ${entries.join(", ")} }` : "{}";
 }
 
-function normalizeValue(v: any) {
+function normalizeValue(v: any): any {
+  if (Array.isArray(v)) {
+    return v.map(normalizeValue);
+  }
+
   if (v instanceof Date) {
-    return v.toISOString(); // TODO update this to use proper Neo4j datetimes
+    return neo4j.types.DateTime.fromStandardDate(v);
   }
   if (typeof v === "object" && v !== null && !Array.isArray(v)) {
     throw new Error(

--- a/packages/kineo/src/kit/utils.ts
+++ b/packages/kineo/src/kit/utils.ts
@@ -75,15 +75,15 @@ export interface ParsedConfig {
  */
 export async function parseConfig(
   jiti: Jiti,
-  module: KineoConfig
+  module: KineoConfig,
 ): Promise<ParsedConfig> {
   const { exported: client, module: clientMod } = await extract(
     jiti,
-    module.client
+    module.client,
   );
   const { exported: schema, module: schemaMod } = await extract(
     jiti,
-    module.schema
+    module.schema,
   );
 
   if (!client) {
@@ -111,7 +111,7 @@ export async function parseConfig(
  */
 async function extract<T>(
   jiti: Jiti,
-  ref: Reference<T>
+  ref: Reference<T>,
 ): Promise<{ module?: FileExport; exported?: T }> {
   if (isReferenceFn(ref)) {
     return { exported: await ref() };
@@ -153,7 +153,7 @@ function isFileExport(ref: Reference<any>): ref is FileExport {
 export async function push(
   adapter: Adapter<any, any>,
   newSchema: Schema,
-  force?: boolean
+  force?: boolean,
 ) {
   if (!adapter.pull) throw new KineoKitError(KineoKitErrorKind.NoSupport);
   if (!adapter.push) throw new KineoKitError(KineoKitErrorKind.NoSupport);
@@ -248,13 +248,13 @@ export function getDiff(prev: Schema, cur: Schema): SchemaDiff {
       if (bothFields) {
         if (prevField.kind !== curField.kind) {
           breaking.push(
-            `In model "${model}", field "${key}" changed kind from "${prevField.kind}" to "${curField.kind}"`
+            `In model "${model}", field "${key}" changed kind from "${prevField.kind}" to "${curField.kind}"`,
           );
         }
 
         if (prevField.isArray !== curField.isArray) {
           breaking.push(
-            `In model "${model}", field "${key}" changed array flag (${prevField.isArray} -> ${curField.isArray})`
+            `In model "${model}", field "${key}" changed array flag (${prevField.isArray} -> ${curField.isArray})`,
           );
         }
 
@@ -262,40 +262,40 @@ export function getDiff(prev: Schema, cur: Schema): SchemaDiff {
           breaking.push(`In model "${model}", field "${key}" became required`);
         } else if (prevField.isRequired && !curField.isRequired) {
           nonBreaking.push(
-            `In model "${model}", field "${key}" became optional`
+            `In model "${model}", field "${key}" became optional`,
           );
         }
       } else if (bothRelations) {
         if (prevField.pointTo !== curField.pointTo) {
           breaking.push(
-            `In model "${model}", relation "${key}" now points to "${curField.pointTo}" instead of "${prevField.pointTo}"`
+            `In model "${model}", relation "${key}" now points to "${curField.pointTo}" instead of "${prevField.pointTo}"`,
           );
         }
 
         if (prevField.isArray !== curField.isArray) {
           breaking.push(
-            `In model "${model}", relation "${key}" changed array flag (${prevField.isArray} -> ${curField.isArray})`
+            `In model "${model}", relation "${key}" changed array flag (${prevField.isArray} -> ${curField.isArray})`,
           );
         }
 
         if (!prevField.isRequired && curField.isRequired) {
           breaking.push(
-            `In model "${model}", relation "${key}" became required`
+            `In model "${model}", relation "${key}" became required`,
           );
         } else if (prevField.isRequired && !curField.isRequired) {
           nonBreaking.push(
-            `In model "${model}", relation "${key}" became optional`
+            `In model "${model}", relation "${key}" became optional`,
           );
         }
 
         if (prevField.relDirection !== curField.relDirection) {
           nonBreaking.push(
-            `In model "${model}", relation "${key}" changed direction (${prevField.relDirection} -> ${curField.relDirection})`
+            `In model "${model}", relation "${key}" changed direction (${prevField.relDirection} -> ${curField.relDirection})`,
           );
         }
       } else if (prevField.constructor !== curField.constructor) {
         breaking.push(
-          `In model "${model}", property "${key}" changed type (field ↔ relation)`
+          `In model "${model}", property "${key}" changed type (field ↔ relation)`,
         );
       }
     }
@@ -326,7 +326,7 @@ export async function pull(adapter: Adapter<any, any>) {
 export async function generate(
   adapter: Adapter<any, any>,
   prevSchema: Schema,
-  newSchema: Schema
+  newSchema: Schema,
 ) {
   if (!adapter.generate) throw new KineoKitError(KineoKitErrorKind.NoSupport);
   return await adapter.generate(prevSchema, newSchema);
@@ -341,7 +341,7 @@ export async function deploy(adapter: Adapter<any, any>, migration: string) {
   if (!adapter.deploy) throw new KineoKitError(KineoKitErrorKind.NoSupport);
   return await adapter.deploy(
     migration,
-    crypto.createHash("sha512").update(JSON.stringify(migration)).digest("hex")
+    crypto.createHash("sha512").update(JSON.stringify(migration)).digest("hex"),
   );
 }
 
@@ -355,7 +355,7 @@ export async function status(adapter: Adapter<any, any>, migration: string) {
   if (!adapter.status) throw new KineoKitError(KineoKitErrorKind.NoSupport);
   return await adapter.status(
     migration,
-    crypto.createHash("sha512").update(JSON.stringify(migration)).digest("hex")
+    crypto.createHash("sha512").update(JSON.stringify(migration)).digest("hex"),
   );
 }
 
@@ -412,7 +412,7 @@ export function decompileEntries([up, down]: Migration): MigrationEntry[] {
 function decompile(
   statements: string[],
   migrations: MigrationEntry[],
-  key: "command" | "reverse"
+  key: "command" | "reverse",
 ) {
   for (const stmt of statements) {
     const split = stmt.split("\n");
@@ -452,7 +452,7 @@ function decompile(
 
 export function filterEntries(
   entries: MigrationEntry[],
-  key: "command" | "reverse"
+  key: "command" | "reverse",
 ) {
   return entries
     .filter((entry) => entry.type === "command")

--- a/packages/kineo/src/kit/utils.ts
+++ b/packages/kineo/src/kit/utils.ts
@@ -75,15 +75,15 @@ export interface ParsedConfig {
  */
 export async function parseConfig(
   jiti: Jiti,
-  module: KineoConfig,
+  module: KineoConfig
 ): Promise<ParsedConfig> {
   const { exported: client, module: clientMod } = await extract(
     jiti,
-    module.client,
+    module.client
   );
   const { exported: schema, module: schemaMod } = await extract(
     jiti,
-    module.schema,
+    module.schema
   );
 
   if (!client) {
@@ -111,7 +111,7 @@ export async function parseConfig(
  */
 async function extract<T>(
   jiti: Jiti,
-  ref: Reference<T>,
+  ref: Reference<T>
 ): Promise<{ module?: FileExport; exported?: T }> {
   if (isReferenceFn(ref)) {
     return { exported: await ref() };
@@ -153,7 +153,7 @@ function isFileExport(ref: Reference<any>): ref is FileExport {
 export async function push(
   adapter: Adapter<any, any>,
   newSchema: Schema,
-  force?: boolean,
+  force?: boolean
 ) {
   if (!adapter.pull) throw new KineoKitError(KineoKitErrorKind.NoSupport);
   if (!adapter.push) throw new KineoKitError(KineoKitErrorKind.NoSupport);
@@ -248,13 +248,13 @@ export function getDiff(prev: Schema, cur: Schema): SchemaDiff {
       if (bothFields) {
         if (prevField.kind !== curField.kind) {
           breaking.push(
-            `In model "${model}", field "${key}" changed kind from "${prevField.kind}" to "${curField.kind}"`,
+            `In model "${model}", field "${key}" changed kind from "${prevField.kind}" to "${curField.kind}"`
           );
         }
 
         if (prevField.isArray !== curField.isArray) {
           breaking.push(
-            `In model "${model}", field "${key}" changed array flag (${prevField.isArray} -> ${curField.isArray})`,
+            `In model "${model}", field "${key}" changed array flag (${prevField.isArray} -> ${curField.isArray})`
           );
         }
 
@@ -262,40 +262,40 @@ export function getDiff(prev: Schema, cur: Schema): SchemaDiff {
           breaking.push(`In model "${model}", field "${key}" became required`);
         } else if (prevField.isRequired && !curField.isRequired) {
           nonBreaking.push(
-            `In model "${model}", field "${key}" became optional`,
+            `In model "${model}", field "${key}" became optional`
           );
         }
       } else if (bothRelations) {
         if (prevField.pointTo !== curField.pointTo) {
           breaking.push(
-            `In model "${model}", relation "${key}" now points to "${curField.pointTo}" instead of "${prevField.pointTo}"`,
+            `In model "${model}", relation "${key}" now points to "${curField.pointTo}" instead of "${prevField.pointTo}"`
           );
         }
 
         if (prevField.isArray !== curField.isArray) {
           breaking.push(
-            `In model "${model}", relation "${key}" changed array flag (${prevField.isArray} -> ${curField.isArray})`,
+            `In model "${model}", relation "${key}" changed array flag (${prevField.isArray} -> ${curField.isArray})`
           );
         }
 
         if (!prevField.isRequired && curField.isRequired) {
           breaking.push(
-            `In model "${model}", relation "${key}" became required`,
+            `In model "${model}", relation "${key}" became required`
           );
         } else if (prevField.isRequired && !curField.isRequired) {
           nonBreaking.push(
-            `In model "${model}", relation "${key}" became optional`,
+            `In model "${model}", relation "${key}" became optional`
           );
         }
 
         if (prevField.relDirection !== curField.relDirection) {
           nonBreaking.push(
-            `In model "${model}", relation "${key}" changed direction (${prevField.relDirection} -> ${curField.relDirection})`,
+            `In model "${model}", relation "${key}" changed direction (${prevField.relDirection} -> ${curField.relDirection})`
           );
         }
       } else if (prevField.constructor !== curField.constructor) {
         breaking.push(
-          `In model "${model}", property "${key}" changed type (field ↔ relation)`,
+          `In model "${model}", property "${key}" changed type (field ↔ relation)`
         );
       }
     }
@@ -326,7 +326,7 @@ export async function pull(adapter: Adapter<any, any>) {
 export async function generate(
   adapter: Adapter<any, any>,
   prevSchema: Schema,
-  newSchema: Schema,
+  newSchema: Schema
 ) {
   if (!adapter.generate) throw new KineoKitError(KineoKitErrorKind.NoSupport);
   return await adapter.generate(prevSchema, newSchema);
@@ -341,7 +341,7 @@ export async function deploy(adapter: Adapter<any, any>, migration: string) {
   if (!adapter.deploy) throw new KineoKitError(KineoKitErrorKind.NoSupport);
   return await adapter.deploy(
     migration,
-    crypto.createHash("sha512").update(JSON.stringify(migration)).digest("hex"),
+    crypto.createHash("sha512").update(JSON.stringify(migration)).digest("hex")
   );
 }
 
@@ -355,7 +355,7 @@ export async function status(adapter: Adapter<any, any>, migration: string) {
   if (!adapter.status) throw new KineoKitError(KineoKitErrorKind.NoSupport);
   return await adapter.status(
     migration,
-    crypto.createHash("sha512").update(JSON.stringify(migration)).digest("hex"),
+    crypto.createHash("sha512").update(JSON.stringify(migration)).digest("hex")
   );
 }
 
@@ -412,7 +412,7 @@ export function decompileEntries([up, down]: Migration): MigrationEntry[] {
 function decompile(
   statements: string[],
   migrations: MigrationEntry[],
-  key: "command" | "reverse",
+  key: "command" | "reverse"
 ) {
   for (const stmt of statements) {
     const split = stmt.split("\n");
@@ -452,7 +452,7 @@ function decompile(
 
 export function filterEntries(
   entries: MigrationEntry[],
-  key: "command" | "reverse",
+  key: "command" | "reverse"
 ) {
   return entries
     .filter((entry) => entry.type === "command")

--- a/packages/kineo/tests/compiler/cypher.test.ts
+++ b/packages/kineo/tests/compiler/cypher.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "vitest";
 import { compile } from "@/compilers/cypher";
 import * as IR from "@/ir";
+import { DateTime } from "neo4j-driver";
 
 describe("compile()", () => {
   test("throws on unsupported statement type", () => {
@@ -228,5 +229,20 @@ describe("compile()", () => {
     expect(command).toContain("<-[:*1..3]->");
     expect(command).toContain("RETURN p");
     expect(command).toContain("LIMIT 2");
+  });
+
+  test("normalizes dates into neo4j date time", () => {
+    const ir = {
+      statements: [
+        {
+          type: IR.StatementType.Create,
+          data: {
+            hello: new Date(),
+          },
+        },
+      ],
+    } as any;
+    const { params } = compile(ir);
+    expect(params["create_hello_1"]).toBeInstanceOf(DateTime);
   });
 });

--- a/packages/kineo/tests/kit/index.test.ts
+++ b/packages/kineo/tests/kit/index.test.ts
@@ -15,7 +15,7 @@ import type { Adapter, MigrationEntry } from "@/adapter";
 
 // A minimal fake adapter
 function createFakeAdapter(
-  overrides: Partial<Adapter<any, any>> = {},
+  overrides: Partial<Adapter<any, any>> = {}
 ): Adapter<any, any> {
   return {
     Model: class FakeModel {},
@@ -36,7 +36,7 @@ describe("push()", () => {
   test("throws if adapter lacks pull or push", async () => {
     const adapter = createFakeAdapter({});
     await expect(push(adapter, simpleSchema)).rejects.toThrowError(
-      KineoKitError,
+      KineoKitError
     );
   });
 
@@ -127,7 +127,7 @@ describe("generate()", () => {
   test("throws if adapter lacks generate", async () => {
     const adapter = createFakeAdapter({});
     await expect(generate(adapter, simpleSchema, simpleSchema)).rejects.toThrow(
-      KineoKitError,
+      KineoKitError
     );
   });
 
@@ -169,7 +169,11 @@ describe("status()", () => {
     });
 
     vi.mock("node:crypto", () => ({
-      default: { hash: vi.fn().mockReturnValue("hash123") },
+      default: {
+        createHash: vi
+          .fn()
+          .mockReturnValue({ update: () => ({ digest: () => "abc123" }) }),
+      },
     }));
 
     const result = await status(adapter, "");
@@ -239,13 +243,13 @@ describe("decompileEntries()", () => {
 
     const command = result.find((x) => x.type === "command" && x.command);
     expect(command?.type === "command" && command?.command).toBe(
-      "CREATE TABLE users",
+      "CREATE TABLE users"
     );
     expect(command?.description).toBe("create users table");
 
     const reverse = result.find((x) => x.type === "command" && x.reverse);
     expect(reverse?.type === "command" && reverse?.reverse).toBe(
-      "DROP TABLE users",
+      "DROP TABLE users"
     );
   });
 
@@ -292,7 +296,7 @@ describe("decompileEntries()", () => {
           type: "note",
           note: "-- Note content",
         }),
-      ]),
+      ])
     );
   });
 });

--- a/packages/kineo/tests/kit/index.test.ts
+++ b/packages/kineo/tests/kit/index.test.ts
@@ -15,7 +15,7 @@ import type { Adapter, MigrationEntry } from "@/adapter";
 
 // A minimal fake adapter
 function createFakeAdapter(
-  overrides: Partial<Adapter<any, any>> = {}
+  overrides: Partial<Adapter<any, any>> = {},
 ): Adapter<any, any> {
   return {
     Model: class FakeModel {},
@@ -36,7 +36,7 @@ describe("push()", () => {
   test("throws if adapter lacks pull or push", async () => {
     const adapter = createFakeAdapter({});
     await expect(push(adapter, simpleSchema)).rejects.toThrowError(
-      KineoKitError
+      KineoKitError,
     );
   });
 
@@ -127,7 +127,7 @@ describe("generate()", () => {
   test("throws if adapter lacks generate", async () => {
     const adapter = createFakeAdapter({});
     await expect(generate(adapter, simpleSchema, simpleSchema)).rejects.toThrow(
-      KineoKitError
+      KineoKitError,
     );
   });
 
@@ -243,13 +243,13 @@ describe("decompileEntries()", () => {
 
     const command = result.find((x) => x.type === "command" && x.command);
     expect(command?.type === "command" && command?.command).toBe(
-      "CREATE TABLE users"
+      "CREATE TABLE users",
     );
     expect(command?.description).toBe("create users table");
 
     const reverse = result.find((x) => x.type === "command" && x.reverse);
     expect(reverse?.type === "command" && reverse?.reverse).toBe(
-      "DROP TABLE users"
+      "DROP TABLE users",
     );
   });
 
@@ -296,7 +296,7 @@ describe("decompileEntries()", () => {
           type: "note",
           note: "-- Note content",
         }),
-      ])
+      ]),
     );
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2
       turbo:
-        specifier: ^2.6.3
-        version: 2.6.3
+        specifier: ^2.7.0
+        version: 2.7.0
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
@@ -1313,38 +1313,38 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  turbo-darwin-64@2.6.3:
-    resolution: {integrity: sha512-BlJJDc1CQ7SK5Y5qnl7AzpkvKSnpkfPmnA+HeU/sgny3oHZckPV2776ebO2M33CYDSor7+8HQwaodY++IINhYg==}
+  turbo-darwin-64@2.7.0:
+    resolution: {integrity: sha512-gwqL7cJOSYrV/jNmhXM8a2uzSFn7GcUASOuen6OgmUsafUj9SSWcgXZ/q0w9hRoL917hpidkdI//UpbxbZbwwg==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.6.3:
-    resolution: {integrity: sha512-MwVt7rBKiOK7zdYerenfCRTypefw4kZCue35IJga9CH1+S50+KTiCkT6LBqo0hHeoH2iKuI0ldTF2a0aB72z3w==}
+  turbo-darwin-arm64@2.7.0:
+    resolution: {integrity: sha512-f3F5DYOnfE6lR6v/rSld7QGZgartKsnlIYY7jcF/AA7Wz27za9XjxMHzb+3i4pvRhAkryFgf2TNq7eCFrzyTpg==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.6.3:
-    resolution: {integrity: sha512-cqpcw+dXxbnPtNnzeeSyWprjmuFVpHJqKcs7Jym5oXlu/ZcovEASUIUZVN3OGEM6Y/OTyyw0z09tOHNt5yBAVg==}
+  turbo-linux-64@2.7.0:
+    resolution: {integrity: sha512-KsC+UuKlhjCL+lom10/IYoxUsdhJOsuEki72YSr7WGYUSRihcdJQnaUyIDTlm0nPOb+gVihVNBuVP4KsNg1UnA==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.6.3:
-    resolution: {integrity: sha512-MterpZQmjXyr4uM7zOgFSFL3oRdNKeflY7nsjxJb2TklsYqiu3Z9pQ4zRVFFH8n0mLGna7MbQMZuKoWqqHb45w==}
+  turbo-linux-arm64@2.7.0:
+    resolution: {integrity: sha512-1tjIYULeJtpmE/ovoI9qPBFJCtUEM7mYfeIMOIs4bXR6t/8u+rHPwr3j+vRHcXanIc42V1n3Pz52VqmJtIAviw==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.6.3:
-    resolution: {integrity: sha512-biDU70v9dLwnBdLf+daoDlNJVvqOOP8YEjqNipBHzgclbQlXbsi6Gqqelp5er81Qo3BiRgmTNx79oaZQTPb07Q==}
+  turbo-windows-64@2.7.0:
+    resolution: {integrity: sha512-KThkAeax46XiH+qICCQm7R8V2pPdeTTP7ArCSRrSLqnlO75ftNm8Ljx4VAllwIZkILrq/GDM8PlyhZdPeUdDxQ==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.6.3:
-    resolution: {integrity: sha512-dDHVKpSeukah3VsI/xMEKeTnV9V9cjlpFSUs4bmsUiLu3Yv2ENlgVEZv65wxbeE0bh0jjpmElDT+P1KaCxArQQ==}
+  turbo-windows-arm64@2.7.0:
+    resolution: {integrity: sha512-kzI6rsQ3Ejs+CkM9HEEP3Z4h5YMCRxwIlQXFQmgXSG3BIgorCkRF2Xr7iQ2i9AGwY/6jbiAYeJbvi3yCp+noFw==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.6.3:
-    resolution: {integrity: sha512-bf6YKUv11l5Xfcmg76PyWoy/e2vbkkxFNBGJSnfdSXQC33ZiUfutYh6IXidc5MhsnrFkWfdNNLyaRk+kHMLlwA==}
+  turbo@2.7.0:
+    resolution: {integrity: sha512-1dUGwi6cSSVZts1BwJa/Gh7w5dPNNGsNWZEAuRKxXWME44hTKWpQZrgiPnqMc5jJJOovzPK5N6tL+PHYRYL5Wg==}
     hasBin: true
 
   type-check@0.4.0:
@@ -2585,32 +2585,32 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  turbo-darwin-64@2.6.3:
+  turbo-darwin-64@2.7.0:
     optional: true
 
-  turbo-darwin-arm64@2.6.3:
+  turbo-darwin-arm64@2.7.0:
     optional: true
 
-  turbo-linux-64@2.6.3:
+  turbo-linux-64@2.7.0:
     optional: true
 
-  turbo-linux-arm64@2.6.3:
+  turbo-linux-arm64@2.7.0:
     optional: true
 
-  turbo-windows-64@2.6.3:
+  turbo-windows-64@2.7.0:
     optional: true
 
-  turbo-windows-arm64@2.6.3:
+  turbo-windows-arm64@2.7.0:
     optional: true
 
-  turbo@2.6.3:
+  turbo@2.7.0:
     optionalDependencies:
-      turbo-darwin-64: 2.6.3
-      turbo-darwin-arm64: 2.6.3
-      turbo-linux-64: 2.6.3
-      turbo-linux-arm64: 2.6.3
-      turbo-windows-64: 2.6.3
-      turbo-windows-arm64: 2.6.3
+      turbo-darwin-64: 2.7.0
+      turbo-darwin-arm64: 2.7.0
+      turbo-linux-64: 2.7.0
+      turbo-linux-arm64: 2.7.0
+      turbo-windows-64: 2.7.0
+      turbo-windows-arm64: 2.7.0
 
   type-check@0.4.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,6 @@
       "cache": false
     },
     "test": {
-      "dependsOn": ["^test"],
       "persistent": true,
       "cache": false
     }


### PR DESCRIPTION
before, things like datetimes were passed directly into the adapter, causing crashes on neo4j because it can only handle primitives, arrays of primitives or their own types. now they get converted to neo4j's `DateTime`
