### PR TITLE
fix: neo4j adapter leaked record aliases

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 trailfrost
+Copyright (c) 2025 sprucepad
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -17,9 +17,8 @@
     "eslint": "^9.36.0",
     "globals": "^16.4.0",
     "prettier": "^3.6.2",
-    "turbo": "^2.7.0",
+    "turbo": "^2.7.3",
     "typescript": "^5.9.2",
-    "typescript-eslint": "^8.44.0",
-    "vitest": "^4.0.15"
+    "typescript-eslint": "^8.44.0"
   }
 }

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kineojs/better-auth",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Kineo plugin/adapter for Better-Auth.",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
@@ -33,6 +33,7 @@
     "@types/node": "~20.19.0",
     "kineo": "workspace:*",
     "tsdown": "^0.18.0",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vitest": "^4.0.15"
   }
 }

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -22,7 +22,7 @@
     "kineo",
     "better-auth"
   ],
-  "author": "trailfrost",
+  "author": "sprucepad",
   "license": "MIT",
   "packageManager": "pnpm@10.24.0",
   "peerDependencies": {

--- a/packages/kineo/LICENSE
+++ b/packages/kineo/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 trailfrost
+Copyright (c) 2025 sprucepad
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/kineo/package.json
+++ b/packages/kineo/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/trailfrost/kineo"
+    "url": "git+https://github.com/sprucepad/kineo"
   },
   "engines": {
     "node": ">= 20.19.0"
@@ -56,7 +56,7 @@
     "object-graph-mapper",
     "object-relation-mapper"
   ],
-  "author": "trailfrost",
+  "author": "sprucepad",
   "license": "MIT",
   "dependencies": {
     "convoker": "^0.3.4",

--- a/packages/kineo/package.json
+++ b/packages/kineo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kineo",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "description": "Declarive, TypeScript-first Object-Relation/Graph Mapper (ORM/OGM).",
   "main": "./dist/index.mjs",
@@ -68,6 +68,7 @@
   "devDependencies": {
     "@types/node": "~20.19.0",
     "tsdown": "^0.18.0",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vitest": "^4.0.15"
   }
 }

--- a/packages/kineo/src/adapters/neo4j.ts
+++ b/packages/kineo/src/adapters/neo4j.ts
@@ -163,10 +163,20 @@ export function Neo4jAdapter(opts: Neo4jOpts): Neo4jAdapter {
 
         for (const key of record.keys) {
           const value = toNative(record.get(key));
-          obj[key.toString()] = value;
 
-          // Collect relationship-like objects
           collectEdges(value, edges);
+
+          // Flatten nodes
+          if (
+            value &&
+            typeof value === "object" &&
+            "labels" in value &&
+            "identity" in value
+          ) {
+            Object.assign(obj, value);
+          } else {
+            obj[key.toString()] = value;
+          }
         }
 
         entries.push(obj);
@@ -724,7 +734,7 @@ function serializeDefault(v: any): string {
  * @param value The value to convert.
  * @returns The converted value.
  */
-function toNative(value: any): any {
+export function toNative(value: any): any {
   if (neo4j.isInt(value)) {
     // convert neo4j.Integer -> number (safe)
     return value.inSafeRange() ? value.toNumber() : value.toBigInt();
@@ -781,7 +791,7 @@ function toNative(value: any): any {
  * @param value The value.
  * @param edges The array to collect to.
  */
-function collectEdges(value: any, edges: any[]) {
+export function collectEdges(value: any, edges: any[]) {
   if (!value) return;
 
   // Relationship-like object (produced by toNative)

--- a/packages/kineo/tests/adapter/neo4j.test.ts
+++ b/packages/kineo/tests/adapter/neo4j.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi, beforeAll, afterAll } from "vitest";
 import neo4j from "neo4j-driver";
-import { Neo4jAdapter, auth } from "@/adapters/neo4j";
+import { Neo4jAdapter, auth, toNative, collectEdges } from "@/adapters/neo4j";
 import { defineSchema, field, model } from "@/schema";
 
 // Neo4j connection settings
@@ -54,7 +54,7 @@ describe("auth()", () => {
 });
 
 describe("Neo4jAdapter (integration)", () => {
-  let adapter: ReturnType<typeof Neo4jAdapter>;
+  let adapter: Neo4jAdapter;
 
   beforeAll(async () => {
     adapter = Neo4jAdapter({
@@ -91,8 +91,8 @@ describe("Neo4jAdapter (integration)", () => {
 
     expect(result.entries.length).toBe(1);
     const entry = result.entries[0];
-    expect(entry.n.name).toBe("Alice");
-    expect(entry.n.age).toBe(30);
+    expect(entry.name).toBe("Alice");
+    expect(entry.age).toBe(30);
     expect(result.summary).toBeDefined();
     expect((result.raw as any).length).toBeGreaterThan(0);
   });
@@ -195,5 +195,179 @@ describe("Neo4jAdapter (integration)", () => {
   test("status() returns pending if migration hash not found", async () => {
     const state = await adapter.status!("", "non-existing-hash");
     expect(state).toBe("pending");
+  });
+
+  // TODO integration tests with client
+});
+
+describe("toNative()", () => {
+  test("converts neo4j Integer to number when safe", () => {
+    const int = neo4j.int(42);
+    const value = toNative(int);
+    expect(value).toBe(42);
+  });
+
+  test("converts neo4j Integer to bigint when unsafe", () => {
+    const big = neo4j.int("9007199254740993"); // > Number.MAX_SAFE_INTEGER
+    const value = toNative(big);
+    expect(typeof value).toBe("bigint");
+  });
+
+  test("converts Node to plain object with identity and labels", () => {
+    const node = new neo4j.types.Node(neo4j.int(1), ["User"], {
+      name: "Alice",
+      age: neo4j.int(30),
+    });
+
+    const value = toNative(node);
+
+    expect(value).toEqual({
+      identity: 1,
+      labels: ["User"],
+      name: "Alice",
+      age: 30,
+    });
+  });
+
+  test("converts Relationship to plain object", () => {
+    const rel = new neo4j.types.Relationship(
+      neo4j.int(5),
+      neo4j.int(1),
+      neo4j.int(2),
+      "KNOWS",
+      { since: neo4j.int(2020) },
+    );
+
+    const value = toNative(rel);
+
+    expect(value).toEqual({
+      identity: 5,
+      start: 1,
+      end: 2,
+      type: "KNOWS",
+      since: 2020,
+    });
+  });
+
+  test("converts Path to flattened structure", () => {
+    const start = new neo4j.types.Node(neo4j.int(1), ["User"], {
+      name: "Alice",
+    });
+
+    const end = new neo4j.types.Node(neo4j.int(2), ["User"], { name: "Bob" });
+
+    const rel = new neo4j.types.Relationship(
+      neo4j.int(3),
+      neo4j.int(1),
+      neo4j.int(2),
+      "KNOWS",
+      {},
+    );
+
+    const segment = new neo4j.types.PathSegment(start, rel, end);
+    const path = new neo4j.types.Path(start, end, [segment]);
+
+    const value = toNative(path);
+
+    expect(value.start.name).toBe("Alice");
+    expect(value.end.name).toBe("Bob");
+    expect(value.segments).toHaveLength(1);
+    expect(value.segments[0].relationship.type).toBe("KNOWS");
+  });
+
+  test("recursively converts arrays and objects", () => {
+    const input = {
+      list: [neo4j.int(1), neo4j.int(2)],
+      nested: {
+        value: neo4j.int(3),
+      },
+    };
+
+    const value = toNative(input);
+
+    expect(value).toEqual({
+      list: [1, 2],
+      nested: { value: 3 },
+    });
+  });
+});
+
+describe("collectEdges()", () => {
+  test("collects relationship-like objects", () => {
+    const rel = {
+      identity: 1,
+      type: "KNOWS",
+      start: 10,
+      end: 20,
+      since: 2021,
+    };
+
+    const edges: any[] = [];
+    collectEdges(rel, edges);
+
+    expect(edges).toEqual([
+      {
+        id: 1,
+        type: "KNOWS",
+        start: 10,
+        end: 20,
+        props: { since: 2021 },
+      },
+    ]);
+  });
+
+  test("collects edges from path-like structure", () => {
+    const path = {
+      segments: [
+        {
+          relationship: {
+            identity: 2,
+            type: "WROTE",
+            start: 1,
+            end: 3,
+            year: 2023,
+          },
+        },
+      ],
+    };
+
+    const edges: any[] = [];
+    collectEdges(path, edges);
+
+    expect(edges).toHaveLength(2);
+    expect(edges[0]).toMatchObject({
+      id: 2,
+      type: "WROTE",
+      start: 1,
+      end: 3,
+      props: { year: 2023 },
+    });
+  });
+
+  test("recursively collects edges from nested objects and arrays", () => {
+    const data = {
+      foo: [
+        {
+          identity: 3,
+          type: "LIKES",
+          start: 1,
+          end: 2,
+          strength: 5,
+        },
+      ],
+    };
+
+    const edges: any[] = [];
+    collectEdges(data, edges);
+
+    expect(edges).toHaveLength(1);
+    expect(edges[0].type).toBe("LIKES");
+    expect(edges[0].props.strength).toBe(5);
+  });
+
+  test("ignores non-relationship values safely", () => {
+    const edges: any[] = [];
+    collectEdges({ a: 1, b: null, c: "x" }, edges);
+    expect(edges).toHaveLength(0);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,17 +24,14 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2
       turbo:
-        specifier: ^2.7.0
-        version: 2.7.0
+        specifier: ^2.7.3
+        version: 2.7.3
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
       typescript-eslint:
         specifier: ^8.44.0
         version: 8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2)
-      vitest:
-        specifier: ^4.0.15
-        version: 4.0.15(@types/node@20.19.27)(jiti@2.5.1)
 
   packages/better-auth:
     dependencies:
@@ -54,6 +51,9 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
+      vitest:
+        specifier: ^4.0.15
+        version: 4.0.15(@types/node@20.19.27)(jiti@2.5.1)
 
   packages/kineo:
     dependencies:
@@ -73,6 +73,9 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
+      vitest:
+        specifier: ^4.0.15
+        version: 4.0.15(@types/node@20.19.27)(jiti@2.5.1)
     optionalDependencies:
       neo4j-driver:
         specifier: ^6.0.0
@@ -1313,38 +1316,38 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  turbo-darwin-64@2.7.0:
-    resolution: {integrity: sha512-gwqL7cJOSYrV/jNmhXM8a2uzSFn7GcUASOuen6OgmUsafUj9SSWcgXZ/q0w9hRoL917hpidkdI//UpbxbZbwwg==}
+  turbo-darwin-64@2.7.3:
+    resolution: {integrity: sha512-aZHhvRiRHXbJw1EcEAq4aws1hsVVUZ9DPuSFaq9VVFAKCup7niIEwc22glxb7240yYEr1vLafdQ2U294Vcwz+w==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.7.0:
-    resolution: {integrity: sha512-f3F5DYOnfE6lR6v/rSld7QGZgartKsnlIYY7jcF/AA7Wz27za9XjxMHzb+3i4pvRhAkryFgf2TNq7eCFrzyTpg==}
+  turbo-darwin-arm64@2.7.3:
+    resolution: {integrity: sha512-CkVrHSq+Bnhl9sX2LQgqQYVfLTWC2gvI74C4758OmU0djfrssDKU9d4YQF0AYXXhIIRZipSXfxClQziIMD+EAg==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.7.0:
-    resolution: {integrity: sha512-KsC+UuKlhjCL+lom10/IYoxUsdhJOsuEki72YSr7WGYUSRihcdJQnaUyIDTlm0nPOb+gVihVNBuVP4KsNg1UnA==}
+  turbo-linux-64@2.7.3:
+    resolution: {integrity: sha512-GqDsCNnzzr89kMaLGpRALyigUklzgxIrSy2pHZVXyifgczvYPnLglex78Aj3T2gu+T3trPPH2iJ+pWucVOCC2Q==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.7.0:
-    resolution: {integrity: sha512-1tjIYULeJtpmE/ovoI9qPBFJCtUEM7mYfeIMOIs4bXR6t/8u+rHPwr3j+vRHcXanIc42V1n3Pz52VqmJtIAviw==}
+  turbo-linux-arm64@2.7.3:
+    resolution: {integrity: sha512-NdCDTfIcIo3dWjsiaAHlxu5gW61Ed/8maah1IAF/9E3EtX0aAHNiBMbuYLZaR4vRJ7BeVkYB6xKWRtdFLZ0y3g==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.7.0:
-    resolution: {integrity: sha512-KThkAeax46XiH+qICCQm7R8V2pPdeTTP7ArCSRrSLqnlO75ftNm8Ljx4VAllwIZkILrq/GDM8PlyhZdPeUdDxQ==}
+  turbo-windows-64@2.7.3:
+    resolution: {integrity: sha512-7bVvO987daXGSJVYBoG8R4Q+csT1pKIgLJYZevXRQ0Hqw0Vv4mKme/TOjYXs9Qb1xMKh51Tb3bXKDbd8/4G08g==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.7.0:
-    resolution: {integrity: sha512-kzI6rsQ3Ejs+CkM9HEEP3Z4h5YMCRxwIlQXFQmgXSG3BIgorCkRF2Xr7iQ2i9AGwY/6jbiAYeJbvi3yCp+noFw==}
+  turbo-windows-arm64@2.7.3:
+    resolution: {integrity: sha512-nTodweTbPmkvwMu/a55XvjMsPtuyUSC+sV7f/SR57K36rB2I0YG21qNETN+00LOTUW9B3omd8XkiXJkt4kx/cw==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.7.0:
-    resolution: {integrity: sha512-1dUGwi6cSSVZts1BwJa/Gh7w5dPNNGsNWZEAuRKxXWME44hTKWpQZrgiPnqMc5jJJOovzPK5N6tL+PHYRYL5Wg==}
+  turbo@2.7.3:
+    resolution: {integrity: sha512-+HjKlP4OfYk+qzvWNETA3cUO5UuK6b5MSc2UJOKyvBceKucQoQGb2g7HlC2H1GHdkfKrk4YF1VPvROkhVZDDLQ==}
     hasBin: true
 
   type-check@0.4.0:
@@ -2585,32 +2588,32 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  turbo-darwin-64@2.7.0:
+  turbo-darwin-64@2.7.3:
     optional: true
 
-  turbo-darwin-arm64@2.7.0:
+  turbo-darwin-arm64@2.7.3:
     optional: true
 
-  turbo-linux-64@2.7.0:
+  turbo-linux-64@2.7.3:
     optional: true
 
-  turbo-linux-arm64@2.7.0:
+  turbo-linux-arm64@2.7.3:
     optional: true
 
-  turbo-windows-64@2.7.0:
+  turbo-windows-64@2.7.3:
     optional: true
 
-  turbo-windows-arm64@2.7.0:
+  turbo-windows-arm64@2.7.3:
     optional: true
 
-  turbo@2.7.0:
+  turbo@2.7.3:
     optionalDependencies:
-      turbo-darwin-64: 2.7.0
-      turbo-darwin-arm64: 2.7.0
-      turbo-linux-64: 2.7.0
-      turbo-linux-arm64: 2.7.0
-      turbo-windows-64: 2.7.0
-      turbo-windows-arm64: 2.7.0
+      turbo-darwin-64: 2.7.3
+      turbo-darwin-arm64: 2.7.3
+      turbo-linux-64: 2.7.3
+      turbo-linux-arm64: 2.7.3
+      turbo-windows-64: 2.7.3
+      turbo-windows-arm64: 2.7.3
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
this caused the return values to be something like `{ n: { name: string } }` instead of just `{ name: string }`