### PR TITLE
feat: add new adapter api

### DIFF
--- a/packages/kineo/src/adapter.ts
+++ b/packages/kineo/src/adapter.ts
@@ -17,7 +17,7 @@ export interface EmitResult {
 /**
  * A emitter.
  */
-export type Emitter<T = any> = (ir: IR, preset?: T) => EmitResult;
+export type Emitter<T = any> = (ir: IR, preset?: T) => Resolvable<EmitResult>;
 
 /**
  * Result of executing a query.
@@ -84,18 +84,6 @@ export function defineEmitter<T>(fn: Emitter<T>): Emitter<T> {
 
 /**
  * Defines an adapter.
- * @param fn Async factory.
- */
-export function defineAdapter<
-  C extends ModelCtor,
-  S = any,
-  P extends any[] = any[],
->(
-  fn: (...args: P) => Promise<Adapter<C, S>>,
-): (...args: P) => Asyncify<Adapter<C, S>>;
-
-/**
- * Defines an adapter.
  * @param a Sync adapter factory.
  */
 export function defineAdapter<
@@ -135,7 +123,7 @@ export function defineAdapter<A extends Adapter<any, any>>(a: unknown) {
   if (typeof a === "function") {
     // an async function?
     if ((a as any)[Symbol.toStringTag] === "AsyncFunction") {
-      return defineAsyncAdapter<A>(a as any); // safe
+      return asyncify<A>(a as any); // safe
     }
 
     // a standard function
@@ -144,7 +132,7 @@ export function defineAdapter<A extends Adapter<any, any>>(a: unknown) {
     const factory = () => a;
 
     if (a instanceof Promise) {
-      return defineAsyncAdapter<A>(factory as any); // safe
+      return asyncify<A>(factory as any); // safe
     }
 
     return factory;
@@ -154,7 +142,7 @@ export function defineAdapter<A extends Adapter<any, any>>(a: unknown) {
 /**
  * Turns every property into a `Promise`, and every function to return a `Promise`.
  */
-type Asyncify<T> = {
+export type Asyncify<T> = {
   [K in keyof T]: T[K] extends (...args: infer A) => infer R
     ? (...args: A) => Promise<R>
     : Promise<T[K]>;
@@ -164,9 +152,7 @@ type Asyncify<T> = {
  * Handles an async adapter factory.
  * @param factory The factory.
  */
-function defineAsyncAdapter<A extends Adapter<any, any>>(
-  adapterPromise: Promise<A>,
-): Asyncify<A> {
+export function asyncify<A>(promise: Promise<A>): Asyncify<A> {
   return new Proxy({} as Asyncify<A>, {
     get(_target, prop) {
       // Special case: allow awaiting the whole adapter
@@ -175,7 +161,7 @@ function defineAsyncAdapter<A extends Adapter<any, any>>(
       }
 
       return async (...args: any[]) => {
-        const adapter = await adapterPromise;
+        const adapter = await promise;
         const value = (adapter as any)[prop];
 
         if (typeof value === "function") {

--- a/packages/kineo/src/adapter.ts
+++ b/packages/kineo/src/adapter.ts
@@ -1,6 +1,5 @@
 import type { IR } from "./ir";
 import type { Model } from "./model";
-import type { Schema } from "./schema";
 
 /**
  * Either a Promise or not.
@@ -70,65 +69,4 @@ export interface Adapter<
    * Closes the adapter.
    */
   close(): Resolvable<void>;
-}
-
-/**
- * An adapter used in KineoKit.
- */
-export interface AdapterKit {
-  /**
-   * Push a schema to the database. You don't need to warn the user, Kineo does that for you.
-   * @param schema The schema to push.
-   */
-  push?(schema: Schema): Resolvable<void>;
-  /**
-   * Gets a schema from the database.
-   */
-  pull?(): Resolvable<{ schema: Schema; full?: boolean }>;
-  /**
-   * Generates migrations.
-   */
-  generate?(prev: Schema, cur: Schema): Resolvable<MigrationEntry[]>;
-  /**
-   * Gets a status for a migration.
-   * @param migration The migration to get the status for.
-   * @param hash The hash of the migration.
-   */
-  status?(migration: string, hash: string): Resolvable<"pending" | "completed">;
-  /**
-   * Deploys a migration.
-   * @param migration The migration to deploy.
-   * @param hash The hash of the migration.
-   */
-  deploy?(migration: string, hash: string): Resolvable<void>;
-}
-
-/**
- * A migration entry. Can either be a note or comment, or a command.
- */
-export type MigrationEntry = MigrationCommand | MigrationNote;
-
-/**
- * A migration note.
- */
-export interface MigrationNote {
-  type: "note";
-  note: string;
-  description?: string;
-}
-
-/**
- * A migration command.
- */
-export interface MigrationCommand {
-  type: "command";
-  /**
-   * The command to run;
-   */
-  command: string;
-  /**
-   * The reverse of the command to run, in case of rollbacks.
-   */
-  reverse?: string;
-  description?: string;
 }

--- a/packages/kineo/src/adapter.ts
+++ b/packages/kineo/src/adapter.ts
@@ -39,14 +39,16 @@ export interface ExecResult<T = any> {
 }
 
 /**
+ * A model constructor, for any inheritors of `Model`.
+ */
+export type ModelCtor = {
+  new (name: string, adapter: Adapter<any, any>): Model<any, any>;
+};
+
+/**
  * An adapter. Contains functions necessary to interact with the database of choice.
  */
-export interface Adapter<
-  TModelCtor extends {
-    new (name: string, adapter: Adapter<any, any>): Model<any, any>;
-  },
-  Summary = any,
-> {
+export interface Adapter<TModelCtor extends ModelCtor, Summary = any> {
   /**
    * What extension of the model class you're using. This can be just the default model or `GraphModel`. Right now, this can't be a custom class.
    */
@@ -69,4 +71,124 @@ export interface Adapter<
    * Closes the adapter.
    */
   close(): Resolvable<void>;
+}
+
+/**
+ * Defines an emitter.
+ * @param fn The emitter function.
+ * @returns The same function.
+ */
+export function defineEmitter<T>(fn: Emitter<T>): Emitter<T> {
+  return fn;
+}
+
+/**
+ * Defines an adapter.
+ * @param fn Async factory.
+ */
+export function defineAdapter<
+  C extends ModelCtor,
+  S = any,
+  P extends any[] = any[],
+>(
+  fn: (...args: P) => Promise<Adapter<C, S>>,
+): (...args: P) => Asyncify<Adapter<C, S>>;
+
+/**
+ * Defines an adapter.
+ * @param a Sync adapter factory.
+ */
+export function defineAdapter<
+  A extends Adapter<any, any>,
+  P extends any[] = any[],
+>(fn: (...args: P) => A): (...args: P) => A;
+
+/**
+ * Defines an adapter.
+ * @param a Async adapter factory.
+ */
+export function defineAdapter<
+  A extends Adapter<any, any>,
+  P extends any[] = any[],
+>(fn: (...args: P) => Promise<A>): (...args: P) => Asyncify<A>;
+
+/**
+ * Defines an adapter.
+ * @param fn Sync adapter.
+ */
+export function defineAdapter<
+  A extends Adapter<any, any>,
+  P extends any[] = any[],
+>(a: A): (...args: P) => A;
+
+/**
+ * Defines an adapter.
+ * @param fn Async adapter.
+ */
+export function defineAdapter<
+  A extends Adapter<any, any>,
+  P extends any[] = any[],
+>(a: Promise<A>): (...args: P) => Asyncify<A>;
+
+export function defineAdapter<A extends Adapter<any, any>>(a: unknown) {
+  // if the parameter is...
+  if (typeof a === "function") {
+    // an async function?
+    if ((a as any)[Symbol.toStringTag] === "AsyncFunction") {
+      return defineAsyncAdapter<A>(a as any); // safe
+    }
+
+    // a standard function
+    return a;
+  } else {
+    const factory = () => a;
+
+    if (a instanceof Promise) {
+      return defineAsyncAdapter<A>(factory as any); // safe
+    }
+
+    return factory;
+  }
+}
+
+/**
+ * Turns every property into a `Promise`, and every function to return a `Promise`.
+ */
+type Asyncify<T> = {
+  [K in keyof T]: T[K] extends (...args: infer A) => infer R
+    ? (...args: A) => Promise<R>
+    : Promise<T[K]>;
+};
+
+/**
+ * Handles an async adapter factory.
+ * @param factory The factory.
+ */
+function defineAsyncAdapter<A extends Adapter<any, any>>(
+  adapterPromise: Promise<A>,
+): Asyncify<A> {
+  return new Proxy({} as Asyncify<A>, {
+    get(_target, prop) {
+      // Special case: allow awaiting the whole adapter
+      if (prop === "then") {
+        return undefined;
+      }
+
+      return async (...args: any[]) => {
+        const adapter = await adapterPromise;
+        const value = (adapter as any)[prop];
+
+        if (typeof value === "function") {
+          return value.apply(adapter, args);
+        }
+
+        // property access -> Promise<property>
+        if (args.length === 0) {
+          return value;
+        }
+
+        throw new TypeError(`${String(prop)} is not a function`);
+      };
+    },
+  });
 }

--- a/packages/kineo/src/adapters/neo4j.ts
+++ b/packages/kineo/src/adapters/neo4j.ts
@@ -129,6 +129,8 @@ export const neo4jAdapter = defineAdapter<Neo4jAdapter, [Neo4jOpts]>((opts) => {
         : driver.session(opts.session);
   return {
     Model: GraphModel,
+    driver,
+    session,
 
     async close() {
       await session.close();
@@ -181,11 +183,6 @@ export const neo4jAdapter = defineAdapter<Neo4jAdapter, [Neo4jOpts]>((opts) => {
         raw: records,
       };
     },
-
-    driver,
-    session,
-
-    // KineoKitin
   };
 });
 

--- a/packages/kineo/src/adapters/neo4j.ts
+++ b/packages/kineo/src/adapters/neo4j.ts
@@ -1,4 +1,4 @@
-import type { Adapter } from "@/adapter";
+import { defineAdapter, type Adapter } from "@/adapter";
 import { GraphModel } from "@/model";
 import { emit } from "@/emitters/cypher";
 import * as neo4j from "neo4j-driver";
@@ -118,7 +118,7 @@ export interface Neo4jAdapter
  * @param opts Options for creating the adapter.
  * @returns A Neo4j adapter.
  */
-export function neo4jAdapter(opts: Neo4jOpts): Neo4jAdapter {
+export const neo4jAdapter = defineAdapter<Neo4jAdapter, [Neo4jOpts]>((opts) => {
   const driver =
     "driver" in opts ? opts.driver : neo4j.driver(opts.url, auth(opts.auth));
   const session =
@@ -187,7 +187,7 @@ export function neo4jAdapter(opts: Neo4jOpts): Neo4jAdapter {
 
     // KineoKitin
   };
-}
+});
 
 /**
  * Converts a Neo4j value to a vanilla JavaScript type.

--- a/packages/kineo/src/emitters/cypher.ts
+++ b/packages/kineo/src/emitters/cypher.ts
@@ -1,4 +1,4 @@
-import type { Emitter } from "@/adapter";
+import { defineEmitter } from "@/adapter";
 import neo4j from "neo4j-driver";
 import * as IR from "@/ir";
 
@@ -12,7 +12,7 @@ type Params = Record<string, any>;
  * @param ir The IR to emit.
  * @returns A compilation result.
  */
-export const emit: Emitter = (ir) => {
+export const emit = defineEmitter((ir) => {
   const ctx = createEmitContext();
   const chunks: string[] = [];
 
@@ -49,7 +49,7 @@ export const emit: Emitter = (ir) => {
   }
 
   return { command: chunks.join("\n\n"), params: ctx.params };
-};
+});
 
 /* -------------------------------------------------------------------------- */
 /*                               Emitter Context                             */

--- a/packages/kineo/src/emitters/sql.ts
+++ b/packages/kineo/src/emitters/sql.ts
@@ -1,4 +1,4 @@
-import type { Emitter } from "@/adapter";
+import { defineEmitter } from "@/adapter";
 import * as IR from "@/ir";
 
 /**
@@ -94,7 +94,7 @@ function createCtx(dialect: Dialect): Ctx {
 /**
  * Emits an IR into SQL, taking in an IR and a dialect.
  */
-const emit: Emitter<Dialect> = (ir, dialect) => {
+const emit = defineEmitter<Dialect>((ir, dialect) => {
   const ctx: Ctx = createCtx(dialect!);
   const sqlStatements: string[] = [];
 
@@ -133,7 +133,7 @@ const emit: Emitter<Dialect> = (ir, dialect) => {
       {} as Record<string, any>,
     ),
   };
-};
+});
 
 export default emit;
 

--- a/packages/kineo/src/index.ts
+++ b/packages/kineo/src/index.ts
@@ -9,4 +9,9 @@ export {
   type ModelDef,
 } from "./schema";
 export { Model, GraphModel } from "./model";
-export type { Adapter, Emitter } from "./adapter";
+export {
+  defineAdapter,
+  defineEmitter,
+  type Adapter,
+  type Emitter,
+} from "./adapter";

--- a/packages/kineo/src/index.ts
+++ b/packages/kineo/src/index.ts
@@ -9,10 +9,4 @@ export {
   type ModelDef,
 } from "./schema";
 export { Model, GraphModel } from "./model";
-export type {
-  Adapter,
-  Emitter,
-  MigrationEntry,
-  MigrationCommand,
-  MigrationNote,
-} from "./adapter";
+export type { Adapter, Emitter } from "./adapter";

--- a/packages/kineo/tests/emitters/cypher.test.ts
+++ b/packages/kineo/tests/emitters/cypher.test.ts
@@ -9,7 +9,7 @@ describe("emit()", () => {
     expect(() => emit(ir as any)).toThrow(/Unsupported statement type/);
   });
 
-  test("emits a Find statement with where, orderBy, skip, take, and include", () => {
+  test("emits a Find statement with where, orderBy, skip, take, and include", async () => {
     const ir = {
       statements: [
         {
@@ -32,7 +32,7 @@ describe("emit()", () => {
       ],
     } as any;
 
-    const { command, params } = emit(ir);
+    const { command, params } = await emit(ir);
 
     expect(command).toContain("MATCH (u:User)");
     expect(command).toContain("WHERE");
@@ -48,7 +48,7 @@ describe("emit()", () => {
     });
   });
 
-  test("emits a Count statement", () => {
+  test("emits a Count statement", async () => {
     const ir = {
       statements: [
         {
@@ -60,13 +60,13 @@ describe("emit()", () => {
       ],
     } as any;
 
-    const { command, params } = emit(ir);
+    const { command, params } = await emit(ir);
     expect(command).toContain("MATCH (u:User)");
     expect(command).toContain("RETURN count(u) AS count");
     expect(Object.keys(params)).toContain("active_1");
   });
 
-  test("emits a Create statement with props and select", () => {
+  test("emits a Create statement with props and select", async () => {
     const ir = {
       statements: [
         {
@@ -79,7 +79,7 @@ describe("emit()", () => {
       ],
     } as any;
 
-    const { command, params } = emit(ir);
+    const { command, params } = await emit(ir);
     expect(command).toContain("CREATE (u:User");
     expect(command).toContain("RETURN u.name AS name");
     expect(params).toMatchObject({
@@ -88,7 +88,7 @@ describe("emit()", () => {
     });
   });
 
-  test("emits an Upsert with both create and update data", () => {
+  test("emits an Upsert with both create and update data", async () => {
     const ir = {
       statements: [
         {
@@ -104,7 +104,7 @@ describe("emit()", () => {
       ],
     } as any;
 
-    const { command, params } = emit(ir);
+    const { command, params } = await emit(ir);
     expect(command).toContain("MERGE (u:User");
     expect(command).toContain("ON CREATE SET");
     expect(command).toContain("ON MATCH SET");
@@ -118,7 +118,7 @@ describe("emit()", () => {
     );
   });
 
-  test("emits an Upsert fallback to simple create when no where keys", () => {
+  test("emits an Upsert fallback to simple create when no where keys", async () => {
     const ir = {
       statements: [
         {
@@ -131,12 +131,12 @@ describe("emit()", () => {
       ],
     } as any;
 
-    const { command } = emit(ir);
+    const { command } = await emit(ir);
     expect(command).toContain("CREATE (u:User");
     expect(command).toContain("RETURN properties(u) AS u");
   });
 
-  test("emits a Delete statement", () => {
+  test("emits a Delete statement", async () => {
     const ir = {
       statements: [
         {
@@ -148,12 +148,12 @@ describe("emit()", () => {
       ],
     } as any;
 
-    const { command, params } = emit(ir);
+    const { command, params } = await emit(ir);
     expect(command).toContain("DELETE u");
     expect(params).toMatchObject({ id_1: 123 });
   });
 
-  test("emits a ConnectQuery statement (OUT direction)", () => {
+  test("emits a ConnectQuery statement (OUT direction)", async () => {
     const ir = {
       statements: [
         {
@@ -168,7 +168,7 @@ describe("emit()", () => {
       ],
     } as any;
 
-    const { command, params } = emit(ir);
+    const { command, params } = await emit(ir);
     expect(command).toContain("MERGE (a)-[r:FRIENDS_WITH");
     expect(command).toContain("RETURN properties(r) AS relation");
     expect(params).toMatchObject({
@@ -178,7 +178,7 @@ describe("emit()", () => {
     });
   });
 
-  test("emits a ConnectQuery with IN and BOTH directions", () => {
+  test("emits a ConnectQuery with IN and BOTH directions", async () => {
     const inIR = {
       statements: [
         {
@@ -204,11 +204,11 @@ describe("emit()", () => {
       ],
     } as any;
 
-    expect(emit(inIR).command).toContain("<-[r:KNOWS");
-    expect(emit(bothIR).command).toContain("-[r:KNOWS");
+    expect((await emit(inIR)).command).toContain("<-[r:KNOWS");
+    expect((await emit(bothIR)).command).toContain("-[r:KNOWS");
   });
 
-  test("emits a RelationQuery statement with min/max/limit/direction", () => {
+  test("emits a RelationQuery statement with min/max/limit/direction", async () => {
     const ir = {
       statements: [
         {
@@ -224,14 +224,14 @@ describe("emit()", () => {
       ],
     } as any;
 
-    const { command } = emit(ir);
+    const { command } = await emit(ir);
     expect(command).toContain("MATCH (a:User)");
     expect(command).toContain("<-[:*1..3]->");
     expect(command).toContain("RETURN p");
     expect(command).toContain("LIMIT 2");
   });
 
-  test("normalizes dates into neo4j date time", () => {
+  test("normalizes dates into neo4j date time", async () => {
     const ir = {
       statements: [
         {
@@ -242,7 +242,7 @@ describe("emit()", () => {
         },
       ],
     } as any;
-    const { params } = emit(ir);
+    const { params } = await emit(ir);
     expect(params["create_hello_1"]).toBeInstanceOf(DateTime);
   });
 });

--- a/packages/kineo/tests/emitters/sql.test.ts
+++ b/packages/kineo/tests/emitters/sql.test.ts
@@ -31,7 +31,7 @@ const mockDialect = {
 };
 
 describe("SQL Emitter", () => {
-  test("emits a simple Find statement", () => {
+  test("emits a simple Find statement", async () => {
     const ir: IR.IR = {
       statements: [
         {
@@ -43,13 +43,13 @@ describe("SQL Emitter", () => {
       ],
     };
 
-    const result = emit(ir, mockDialect);
+    const result = await emit(ir, mockDialect);
     expect(result.command).toContain('SELECT "id", "name" FROM "User"');
     expect(result.command).toContain('WHERE "id" = 1');
     expect(result.params).toEqual({});
   });
 
-  test("emits a Find with orderBy and pagination", () => {
+  test("emits a Find with orderBy and pagination", async () => {
     const ir: IR.IR = {
       statements: [
         {
@@ -62,13 +62,13 @@ describe("SQL Emitter", () => {
       ],
     };
 
-    const result = emit(ir, mockDialect);
+    const result = await emit(ir, mockDialect);
     expect(result.command).toContain('SELECT * FROM "Post"');
     expect(result.command).toContain('ORDER BY "createdAt" DESC');
     expect(result.command).toContain("LIMIT 10 OFFSET 5");
   });
 
-  test("emits a Count statement with WHERE clause", () => {
+  test("emits a Count statement with WHERE clause", async () => {
     const ir: IR.IR = {
       statements: [
         {
@@ -79,13 +79,13 @@ describe("SQL Emitter", () => {
       ],
     };
 
-    const result = emit(ir, mockDialect);
+    const result = await emit(ir, mockDialect);
     expect(result.command).toBe(
       'SELECT COUNT(*) AS count FROM "User" WHERE "active" = TRUE',
     );
   });
 
-  test("emits a Create statement with data", () => {
+  test("emits a Create statement with data", async () => {
     const ir: IR.IR = {
       statements: [
         {
@@ -97,13 +97,13 @@ describe("SQL Emitter", () => {
       ],
     };
 
-    const result = emit(ir, mockDialect);
+    const result = await emit(ir, mockDialect);
     expect(result.command).toBe(
       'INSERT INTO "User" ("name", "age") VALUES (\'Alice\', 30) RETURNING id',
     );
   });
 
-  test("emits a Create with empty data (DEFAULT VALUES)", () => {
+  test("emits a Create with empty data (DEFAULT VALUES)", async () => {
     const ir: IR.IR = {
       statements: [
         {
@@ -114,11 +114,11 @@ describe("SQL Emitter", () => {
       ],
     };
 
-    const result = emit(ir, mockDialect);
+    const result = await emit(ir, mockDialect);
     expect(result.command).toContain('INSERT INTO "User" DEFAULT VALUES');
   });
 
-  test("emits an Upsert statement", () => {
+  test("emits an Upsert statement", async () => {
     const ir: IR.IR = {
       statements: [
         {
@@ -134,12 +134,12 @@ describe("SQL Emitter", () => {
       ],
     };
 
-    const result = emit(ir, mockDialect);
+    const result = await emit(ir, mockDialect);
     expect(result.command).toContain('UPSERT INTO "User"');
     expect(mockDialect.upsert).toHaveBeenCalled();
   });
 
-  test("emits a Delete statement with WHERE", () => {
+  test("emits a Delete statement with WHERE", async () => {
     const ir: IR.IR = {
       statements: [
         {
@@ -150,7 +150,7 @@ describe("SQL Emitter", () => {
       ],
     };
 
-    const result = emit(ir, mockDialect);
+    const result = await emit(ir, mockDialect);
     expect(result.command).toBe('DELETE FROM "User" WHERE "id" = 42');
   });
 
@@ -170,7 +170,7 @@ describe("SQL Emitter", () => {
     expect(() => emit(ir, mockDialect)).toThrow(/graph operations/);
   });
 
-  test("supports JSON path extraction in where clause", () => {
+  test("supports JSON path extraction in where clause", async () => {
     const ir: IR.IR = {
       statements: [
         {
@@ -181,7 +181,7 @@ describe("SQL Emitter", () => {
       ],
     };
 
-    const result = emit(ir, mockDialect);
+    const result = await emit(ir, mockDialect);
     expect(result.command).toContain("JSON_EXTRACT");
   });
 });

--- a/packages/kineokit/package.json
+++ b/packages/kineokit/package.json
@@ -12,6 +12,10 @@
       "types": "./dist/index.d.mts",
       "import": "./dist/index.mjs"
     },
+    "./adapter": {
+      "types": "./dist/adapter.d.mts",
+      "import": "./dist/adapter.mjs"
+    },
     "./adapters/neo4j": {
       "types": "./dist/adapters/neo4j.d.mts",
       "import": "./dist/adapters/neo4j.mjs"

--- a/packages/kineokit/src/adapter.ts
+++ b/packages/kineokit/src/adapter.ts
@@ -1,0 +1,70 @@
+import type { Schema } from "kineo/schema";
+
+/**
+ * Either a Promise or not.
+ */
+type Resolvable<T> = T | Promise<T>;
+
+/**
+ * An adapter used in KineoKit.
+ */
+export interface AdapterKit {
+  /**
+   * Push a schema to the database. You don't need to warn the user, Kineo does that for you.
+   * @param schema The schema to push.
+   */
+  push?(schema: Schema): Resolvable<void>;
+  /**
+   * Gets a schema from the database.
+   */
+  pull?(): Resolvable<{ schema: Schema; full?: boolean }>;
+  /**
+   * Generates migrations.
+   */
+  generate?(prev: Schema, cur: Schema): Resolvable<MigrationEntry[]>;
+  /**
+   * Gets a status for a migration.
+   * @param migration The migration to get the status for.
+   * @param hash The hash of the migration.
+   */
+  status?(migration: string, hash: string): Resolvable<"pending" | "completed">;
+  /**
+   * Deploys a migration.
+   * @param migration The migration to deploy.
+   * @param hash The hash of the migration.
+   */
+  deploy?(migration: string, hash: string): Resolvable<void>;
+}
+
+/**
+ * A migration entry. Can either be a note or comment, or a command.
+ */
+export type MigrationEntry = MigrationCommand | MigrationNote;
+
+/**
+ * A migration note.
+ */
+export interface MigrationNote {
+  type: "note";
+  note: string;
+  description?: string;
+}
+
+/**
+ * A migration command.
+ */
+export interface MigrationCommand {
+  type: "command";
+  /**
+   * The command to run;
+   */
+  command: string;
+  /**
+   * The reverse of the command to run, in case of rollbacks.
+   */
+  reverse?: string;
+  /**
+   * A description of the migration command.
+   */
+  description?: string;
+}

--- a/packages/kineokit/src/adapter.ts
+++ b/packages/kineokit/src/adapter.ts
@@ -1,3 +1,4 @@
+import { asyncify, type Asyncify } from "kineo/adapter";
 import type { Schema } from "kineo/schema";
 
 /**
@@ -67,4 +68,57 @@ export interface MigrationCommand {
    * A description of the migration command.
    */
   description?: string;
+}
+
+/**
+ * Defines an adapter.
+ * @param a Sync adapter factory.
+ */
+export function defineAdapterKit<A extends AdapterKit, P extends any[] = any[]>(
+  fn: (...args: P) => A,
+): (...args: P) => A;
+
+/**
+ * Defines an adapter.
+ * @param a Async adapter factory.
+ */
+export function defineAdapterKit<A extends AdapterKit, P extends any[] = any[]>(
+  fn: (...args: P) => Promise<A>,
+): (...args: P) => Asyncify<A>;
+
+/**
+ * Defines an adapter.
+ * @param fn Sync adapter.
+ */
+export function defineAdapterKit<A extends AdapterKit, P extends any[] = any[]>(
+  a: A,
+): (...args: P) => A;
+
+/**
+ * Defines an adapter.
+ * @param fn Async adapter.
+ */
+export function defineAdapterKit<A extends AdapterKit, P extends any[] = any[]>(
+  a: Promise<A>,
+): (...args: P) => Asyncify<A>;
+
+export function defineAdapterKit<A extends AdapterKit>(a: unknown) {
+  // if the parameter is...
+  if (typeof a === "function") {
+    // an async function?
+    if ((a as any)[Symbol.toStringTag] === "AsyncFunction") {
+      return asyncify<A>(a as any); // safe
+    }
+
+    // a standard function
+    return a;
+  } else {
+    const factory = () => a;
+
+    if (a instanceof Promise) {
+      return asyncify<A>(factory as any); // safe
+    }
+
+    return factory;
+  }
 }

--- a/packages/kineokit/src/adapters/neo4j.ts
+++ b/packages/kineokit/src/adapters/neo4j.ts
@@ -1,6 +1,11 @@
+import {
+  defineAdapterKit,
+  type AdapterKit,
+  type MigrationEntry,
+} from "@/adapter";
+
 import neo4j, { Session, type Driver, type SessionConfig } from "neo4j-driver";
 import { auth, type Neo4jAdapter, type Neo4jOpts } from "kineo/adapters/neo4j";
-import type { AdapterKit, MigrationEntry } from "kineo/adapter";
 import {
   field,
   FieldDef,
@@ -27,9 +32,10 @@ export interface Neo4jKit extends AdapterKit {
  * @param opts Runtime adapter, client or options for creating the adapter.
  * @returns A Neo4j KineoKit adapter.
  */
-export function neo4jKit(
-  opts: Neo4jOpts | Neo4jAdapter | Kineo<any, any>,
-): Neo4jKit {
+export const neo4jKit = defineAdapterKit<
+  Neo4jKit,
+  [Neo4jOpts | Neo4jAdapter | Kineo<any, any>]
+>((opts) => {
   const { driver, session } = getDriverSession(opts);
 
   return {
@@ -522,7 +528,7 @@ export function neo4jKit(
       return migrations;
     },
   };
-}
+});
 
 /**
  * Extracts a driver and a session from options, a runtime adapter or a client.

--- a/packages/kineokit/src/config.ts
+++ b/packages/kineokit/src/config.ts
@@ -1,4 +1,4 @@
-import type { AdapterKit } from "kineo/adapter";
+import type { AdapterKit } from "./adapter";
 import { KineoKitError, KineoKitErrorKind } from "./error";
 import type { Schema } from "kineo/schema";
 import type { FileExport, KineoConfig, Reference, ReferenceFn } from ".";

--- a/packages/kineokit/src/index.ts
+++ b/packages/kineokit/src/index.ts
@@ -1,5 +1,5 @@
 import type { Kineo } from "kineo/client";
-import type { AdapterKit } from "kineo/adapter";
+import type { AdapterKit } from "./adapter";
 import type { Schema } from "kineo/schema";
 
 /**

--- a/packages/kineokit/src/kit.ts
+++ b/packages/kineokit/src/kit.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 
-import type { AdapterKit } from "kineo/adapter";
+import type { AdapterKit } from "./adapter";
 import { FieldDef, RelationDef, type Schema } from "kineo/schema";
 import { KineoKitError, KineoKitErrorKind } from "./error";
 

--- a/packages/kineokit/src/migration.ts
+++ b/packages/kineokit/src/migration.ts
@@ -1,4 +1,4 @@
-import type { MigrationEntry } from "kineo/adapter";
+import type { MigrationEntry } from "@/adapter";
 
 /**
  * An [up, down] migration.

--- a/packages/kineokit/tests/config.test.ts
+++ b/packages/kineokit/tests/config.test.ts
@@ -1,9 +1,10 @@
 import { parseConfig } from "@/config";
 import type { KineoConfig } from "@/index";
+import type { AdapterKit } from "@/adapter";
 
 import { kineo } from "kineo/client";
 import { defineSchema } from "kineo/schema";
-import type { Adapter, AdapterKit } from "kineo/adapter";
+import type { Adapter } from "kineo/adapter";
 import { GraphModel } from "kineo/model";
 
 import { describe, expect, test, vi } from "vitest";

--- a/packages/kineokit/tests/kit.test.ts
+++ b/packages/kineokit/tests/kit.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi } from "vitest";
 import { model, defineSchema, field } from "kineo/schema";
-import type { AdapterKit } from "kineo/adapter";
+import type { AdapterKit } from "@/adapter";
 
 import { push, pull, generate, deploy, status, getDiff } from "@/kit";
 import { KineoKitError, KineoKitErrorKind } from "@/error";

--- a/packages/kineokit/tests/migrations.test.ts
+++ b/packages/kineokit/tests/migrations.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import type { MigrationEntry } from "kineo/adapter";
+import type { MigrationEntry } from "@/adapter";
 
 import { toMigration, toEntries } from "@/migration";
 

--- a/packages/kineokit/tsdown.config.ts
+++ b/packages/kineokit/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig([
   {
-    entry: ["./src/index.ts", "./src/adapters/neo4j.ts"],
+    entry: ["./src/index.ts", "./src/adapter.ts", "./src/adapters/neo4j.ts"],
     external: ["neo4j-driver"],
     dts: true,
     minify: true,


### PR DESCRIPTION
old api remains the same, but now you have `defineAdapter` and `defineAdapterKit` factories that handle async adapters

this also moves adapter kits to kineokit
