### PR TITLE
feat: allow unique fields and indexes, allow better auth plugins, simplify kineokit adapter layer

### DIFF
--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -1,9 +1,13 @@
 {
   "name": "@kineojs/better-auth",
-  "version": "0.3.1",
-  "description": "Kineo plugin/adapter for Better-Auth.",
-  "main": "./dist/index.mjs",
-  "types": "./dist/index.d.mts",
+  "version": "0.4.0",
+  "description": "Kineo database adapter for Better-Auth.",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    }
+  },
   "engines": {
     "node": ">= 20.19.0"
   },
@@ -31,7 +35,7 @@
     "kineo": "workspace:*"
   },
   "devDependencies": {
-    "kineo": "workspace:*",
-    "better-auth": "^1.0.0"
+    "better-auth": "^1.0.0",
+    "kineo": "workspace:*"
   }
 }

--- a/packages/better-auth/src/index.ts
+++ b/packages/better-auth/src/index.ts
@@ -1,65 +1,8 @@
-import {
-  defineSchema,
-  field,
-  model,
-  relation,
-  type Schema,
-} from "kineo/schema";
+import type { Schema } from "kineo/schema";
 import type { Adapter } from "kineo/adapter";
 import type { Kineo } from "kineo/client";
 import { createAdapterFactory } from "better-auth/adapters";
 import { emit } from "./emitter";
-
-/**
- * The schema used by Better-Auth, that you can spread onto your schema.
- */
-export const betterAuthSchema = defineSchema({
-  users: model("user", {
-    id: field.string().id(),
-    name: field.string().required(),
-    email: field.string().required(),
-    emailVerified: field.bool().default(false),
-    image: field.string().optional(),
-    createdAt: field.datetime().required(),
-    updatedAt: field.datetime().required(),
-  }),
-
-  sessions: model("session", {
-    id: field.string().id(),
-    userId: relation.to("user").required(),
-    token: field.string().required(),
-    expiresAt: field.datetime().required(),
-    ipAddress: field.string().optional(),
-    userAgent: field.string().optional(),
-    createdAt: field.datetime().required(),
-    updatedAt: field.datetime().required(),
-  }),
-
-  accounts: model("account", {
-    id: field.string().id(),
-    userId: relation.to("user").required(),
-    accountId: field.string().required(),
-    providerId: field.string().required(),
-    accessToken: field.string().optional(),
-    refreshToken: field.string().optional(),
-    accessTokenExpiresAt: field.datetime().optional(),
-    refreshTokenExpiresAt: field.datetime().optional(),
-    scope: field.string().optional(),
-    idToken: field.string().optional(),
-    password: field.string().optional(),
-    createdAt: field.datetime().required(),
-    updatedAt: field.datetime().required(),
-  }),
-
-  verifications: model("verification", {
-    id: field.string().id(),
-    identifier: field.string().required(),
-    value: field.string().required(),
-    expiresAt: field.datetime().required(),
-    createdAt: field.datetime().required(),
-    updatedAt: field.datetime().required(),
-  }),
-});
 
 /**
  * Creates a Better-Auth adapter from a Kineo client.
@@ -122,3 +65,5 @@ async function exec(
   const result = await client.$adapter.emit(ir);
   return (await client.$adapter.exec(result)) as any;
 }
+
+export { betterAuthSchema } from "./schema";

--- a/packages/better-auth/src/schema.ts
+++ b/packages/better-auth/src/schema.ts
@@ -1,0 +1,130 @@
+import type { BetterAuthPlugin, BetterAuthPluginDBSchema } from "better-auth";
+import {
+  defineSchema,
+  field,
+  model,
+  relation,
+  type ModelDef,
+  type ModelShape,
+} from "kineo/schema";
+
+/**
+ * Creates a schema based on your Better-Auth plugins that you can spread onto your schema.
+ */
+export function betterAuthSchema(...plugins: BetterAuthPlugin[]) {
+  const pluginSchemas = plugins.map((plugin) => toKineoSchema(plugin.schema));
+
+  return Object.assign(
+    defineSchema({
+      users: model("user", {
+        id: field.string().id(),
+        name: field.string().required(),
+        email: field.string().required(),
+        emailVerified: field.bool().default(false),
+        image: field.string().optional(),
+        createdAt: field.datetime().required(),
+        updatedAt: field.datetime().required(),
+      }),
+
+      sessions: model("session", {
+        id: field.string().id(),
+        userId: relation.to("user").required(),
+        token: field.string().required(),
+        expiresAt: field.datetime().required(),
+        ipAddress: field.string().optional(),
+        userAgent: field.string().optional(),
+        createdAt: field.datetime().required(),
+        updatedAt: field.datetime().required(),
+      }),
+
+      accounts: model("account", {
+        id: field.string().id(),
+        userId: relation.to("user").required(),
+        accountId: field.string().required(),
+        providerId: field.string().required(),
+        accessToken: field.string().optional(),
+        refreshToken: field.string().optional(),
+        accessTokenExpiresAt: field.datetime().optional(),
+        refreshTokenExpiresAt: field.datetime().optional(),
+        scope: field.string().optional(),
+        idToken: field.string().optional(),
+        password: field.string().optional(),
+        createdAt: field.datetime().required(),
+        updatedAt: field.datetime().required(),
+      }),
+
+      verifications: model("verification", {
+        id: field.string().id(),
+        identifier: field.string().required(),
+        value: field.string().required(),
+        expiresAt: field.datetime().required(),
+        createdAt: field.datetime().required(),
+        updatedAt: field.datetime().required(),
+      }),
+    }),
+
+    ...pluginSchemas,
+  );
+}
+
+export function toKineoSchema(schema?: BetterAuthPluginDBSchema) {
+  if (!schema) return null;
+
+  const models: Record<string, ModelDef<any>> = {};
+  for (const modelKey in schema) {
+    const baModel = schema[modelKey];
+
+    const fields: ModelShape = {};
+    for (const fieldKey in baModel.fields) {
+      const baField = baModel.fields[fieldKey];
+      let f: ModelShape[string];
+
+      if (baField.references) {
+        f = relation
+          .to(baField.references.model)
+          .both(baField.references.field);
+      } else {
+        switch (baField.type) {
+          case "boolean":
+            f = field.bool(baField.fieldName);
+            break;
+          case "date":
+            f = field.datetime(baField.fieldName);
+            break;
+          case "json":
+            // TODO json
+            f = field.string(baField.fieldName);
+            break;
+          case "number":
+            f = field.int(baField.fieldName);
+            break;
+          case "number[]":
+            f = field.int(baField.fieldName).array();
+            break;
+          case "string":
+            f = field.string(baField.fieldName);
+            break;
+          case "string[]":
+            f = field.string(baField.fieldName).array();
+            break;
+          default:
+            throw new Error("[@kineojs/better-auth] unsupported database type");
+        }
+      }
+
+      // TODO bigint
+      if (baField.defaultValue) f.default(baField.defaultValue);
+      if (baField.index) f.index(`better_auth_${f.$name ?? fieldKey}`);
+      if (baField.required) f.required();
+      if (baField.unique) f.unique();
+      // TODO validator
+
+      fields[fieldKey] = f;
+    }
+
+    models[modelKey] = model(baModel.modelName ?? modelKey, fields);
+  }
+
+  // TODO check if baField.references.model is model key or model name,
+  // TODO and transform into model key if it _is_ model name
+}

--- a/packages/better-auth/src/schema.ts
+++ b/packages/better-auth/src/schema.ts
@@ -92,11 +92,11 @@ export function toKineoSchema(schema?: BetterAuthPluginDBSchema) {
             f = field.datetime(baField.fieldName);
             break;
           case "json":
-            // TODO json
             f = field.string(baField.fieldName);
             break;
           case "number":
-            f = field.int(baField.fieldName);
+            if (baField.bigint) f = field.bigint(baField.fieldName);
+            else f = field.int(baField.fieldName);
             break;
           case "number[]":
             f = field.int(baField.fieldName).array();
@@ -112,19 +112,15 @@ export function toKineoSchema(schema?: BetterAuthPluginDBSchema) {
         }
       }
 
-      // TODO bigint
       if (baField.defaultValue) f.default(baField.defaultValue);
       if (baField.index) f.index(`better_auth_${f.$name ?? fieldKey}`);
       if (baField.required) f.required();
       if (baField.unique) f.unique();
-      // TODO validator
+      if (baField.validator?.output) f.validate(baField.validator.output);
 
       fields[fieldKey] = f;
     }
 
     models[modelKey] = model(baModel.modelName ?? modelKey, fields);
   }
-
-  // TODO check if baField.references.model is model key or model name,
-  // TODO and transform into model key if it _is_ model name
 }

--- a/packages/better-auth/tests/adapter.test.ts
+++ b/packages/better-auth/tests/adapter.test.ts
@@ -24,7 +24,7 @@ describe("kineoAdapter", () => {
 
     client = {
       $adapter: {
-        emit: vi.fn().mockResolvedValue("emitd-ir"),
+        emit: vi.fn().mockResolvedValue("emitted-ir"),
         exec: vi.fn().mockResolvedValue(execResult),
       },
     };
@@ -47,7 +47,7 @@ describe("kineoAdapter", () => {
     });
 
     expect(client.$adapter.emit).toHaveBeenCalledWith("ir");
-    expect(client.$adapter.exec).toHaveBeenCalledWith("emitd-ir");
+    expect(client.$adapter.exec).toHaveBeenCalledWith("emitted-ir");
     expect(result).toBe(5);
   });
 

--- a/packages/kineo/package.json
+++ b/packages/kineo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kineo",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "type": "module",
   "description": "Declarive, TypeScript-first Object-Relation/Graph Mapper (ORM/OGM).",
   "repository": {

--- a/packages/kineo/src/adapter.ts
+++ b/packages/kineo/src/adapter.ts
@@ -1,5 +1,6 @@
 import type { IR } from "./ir";
 import type { Model } from "./model";
+import type { ModelDef } from "./schema";
 
 /**
  * Either a Promise or not.
@@ -42,7 +43,11 @@ export interface ExecResult<T = any> {
  * A model constructor, for any inheritors of `Model`.
  */
 export type ModelCtor = {
-  new (name: string, adapter: Adapter<any, any>): Model<any, any>;
+  new (
+    def: ModelDef<any>,
+    name: string,
+    adapter: Adapter<any, any>,
+  ): Model<any, any>;
 };
 
 /**

--- a/packages/kineo/src/client.ts
+++ b/packages/kineo/src/client.ts
@@ -1,4 +1,4 @@
-import type { InferSchema, ModelDef, Schema } from "./schema";
+import { model, type InferSchema, type ModelDef, type Schema } from "./schema";
 import type { Model, GraphModel } from "./model";
 import type { Adapter } from "./adapter";
 
@@ -53,7 +53,14 @@ export function kineo<
 >(adapter: TAdapter, schema: TSchema): Kineo<TSchema, TAdapter> {
   const modelsForSchema: Partial<ModelsForSchema<TSchema, TAdapter>> = {};
   for (const key in schema) {
-    modelsForSchema[key] = new adapter.Model(schema[key].$name ?? key, adapter);
+    const modelDef = schema[key];
+    modelDef.update();
+
+    modelsForSchema[key] = new adapter.Model(
+      modelDef,
+      modelDef.$name ?? key,
+      adapter,
+    );
   }
 
   return {

--- a/packages/kineo/src/client.ts
+++ b/packages/kineo/src/client.ts
@@ -1,4 +1,4 @@
-import { model, type InferSchema, type ModelDef, type Schema } from "./schema";
+import type { InferSchema, ModelDef, Schema } from "./schema";
 import type { Model, GraphModel } from "./model";
 import type { Adapter } from "./adapter";
 

--- a/packages/kineo/src/emitters/cypher.ts
+++ b/packages/kineo/src/emitters/cypher.ts
@@ -83,7 +83,7 @@ function createEmitContext(): EmitContext {
  * @param ctx The emitter context.
  * @param prefix The prefix of the property.
  * @param props The properties to convert.
- * @returns The emitd properties.
+ * @returns The emitted properties.
  */
 function propsToCypher(
   ctx: EmitContext,

--- a/packages/kineo/src/emitters/cypher.ts
+++ b/packages/kineo/src/emitters/cypher.ts
@@ -208,7 +208,7 @@ function projection(
   const fields: string[] = [];
 
   if (select && Object.keys(select).length) {
-    for (const key of Object.keys(select)) {
+    for (const key in select) {
       fields.push(`${alias}.${key} AS ${key}`);
     }
   } else {

--- a/packages/kineo/src/emitters/sql.ts
+++ b/packages/kineo/src/emitters/sql.ts
@@ -181,14 +181,14 @@ function emitWhere(ctx: Ctx, where?: Record<string, any>): string | undefined {
 
     // otherwise, assume a map of fields -> constraints
     const pieces: string[] = [];
-    for (const k of Object.keys(obj)) {
+    for (const k in obj) {
       const v = obj[k];
 
       // nested logical inside field is not expected
       // handle operators if v is object with operator keys
       if (v && typeof v === "object" && !Array.isArray(v)) {
         // operator map
-        for (const opKey of Object.keys(v)) {
+        for (const opKey in v) {
           const operand = v[opKey];
           const colExpr = emitColumnOrJson(ctx, k);
           switch (opKey) {

--- a/packages/kineo/src/ir.ts
+++ b/packages/kineo/src/ir.ts
@@ -24,7 +24,7 @@ export interface Statement {
 }
 
 /**
- * IR root — represents a emitd set of model operations
+ * IR root — represents a emitted set of model operations
  */
 export interface IR {
   statements: Statement[];

--- a/packages/kineo/src/model/model.ts
+++ b/packages/kineo/src/model/model.ts
@@ -1,5 +1,5 @@
 import type { Adapter } from "@/adapter";
-import type { InferModelShape, ModelShape, Schema } from "@/schema";
+import type { InferModelShape, ModelDef, ModelShape, Schema } from "@/schema";
 import * as ir from "@/ir";
 
 // ---------- Generic Utility Types ---------- //
@@ -286,28 +286,20 @@ export type UpsertManyReturn<
  */
 export class Model<S extends Schema, M extends ModelShape> {
   /**
-   * The name of the model.
-   */
-  protected $name: string;
-  /**
-   * The adapter.
-   */
-  protected $adapter: Adapter<any, any>;
-
-  /**
    * Creates a new model. This is usually done by Kineo -- it is not recommended to create a model manually like this.
    * @param name The name of the model.
    * @param adapter The adapter.
    */
-  constructor(name: string, adapter: Adapter<any, any>) {
-    this.$name = name;
-    this.$adapter = adapter;
-  }
+  constructor(
+    protected $def: ModelDef<M>,
+    protected $name: string,
+    protected $adapter: Adapter<any, any>,
+  ) {}
 
   protected async $exec(opts: any, op: string) {
     const tree = ir.emitToIR(this.$name, op, opts);
-    const emitd = await this.$adapter.emit(tree);
-    const result = await this.$adapter.exec(emitd);
+    const emitted = await this.$adapter.emit(tree);
+    const result = await this.$adapter.exec(emitted);
 
     return result;
   }

--- a/packages/kineo/src/model/model.ts
+++ b/packages/kineo/src/model/model.ts
@@ -301,6 +301,12 @@ export class Model<S extends Schema, M extends ModelShape> {
     const emitted = await this.$adapter.emit(tree);
     const result = await this.$adapter.exec(emitted);
 
+    for (const entry of result.entries) {
+      for (const key in entry) {
+        await this.$def.$schemas.get(key)?.["~standard"].validate(entry[key]);
+      }
+    }
+
     return result;
   }
 

--- a/packages/kineo/src/schema/field.ts
+++ b/packages/kineo/src/schema/field.ts
@@ -39,6 +39,14 @@ export class FieldDef<
    * The default value of the field.
    */
   $default: TDefault = undefined as any;
+  /**
+   * The index name of the field.
+   */
+  $indexName?: string;
+  /**
+   * If this field is unique.
+   */
+  $unique = false;
 
   /**
    * Creates a new field definition
@@ -55,7 +63,7 @@ export class FieldDef<
    * @param kind The new type.
    * @returns `this`.
    */
-  type<T extends Kind>(kind: T): FieldDef<T, TId, TRequired, TArray, T> {
+  type<T extends Kind>(kind: T): FieldDef<T, TId, TRequired, TArray, TDefault> {
     this.$kind = kind as any;
     return this as any;
   }
@@ -124,6 +132,34 @@ export class FieldDef<
     this.$default = value as any;
     return this as any;
   }
+
+  /**
+   * The index name.
+   * @param name The name of the index.
+   * @returns `this`.
+   */
+  index(name: string): this {
+    this.$indexName = name;
+    return this;
+  }
+
+  /**
+   * Sets the field as unique.
+   * @returns `this`.
+   */
+  unique(): this {
+    this.$unique = true;
+    return this;
+  }
+
+  /**
+   * Sets the field as common (not unique).
+   * @returns `this`.
+   */
+  common(): this {
+    this.$unique = false;
+    return this;
+  }
 }
 
 /**
@@ -140,11 +176,34 @@ export class RelationDef<
   TArray extends boolean = false,
   TDefault = undefined,
 > {
+  /**
+   * If this relationship is required.
+   */
   $required: TRequired = false as any;
+  /**
+   * If this is a list of relationships.
+   */
   $array: TArray = false as any;
+  /**
+   * The default value of the relationship.
+   */
   $default: TDefault = undefined as any;
+  /**
+   * The direction of the relationship.
+   */
   $direction?: Direction;
+  /**
+   * The relationship label.
+   */
   $label?: string;
+  /**
+   * The relationship index name.
+   */
+  $indexName?: string;
+  /**
+   * If this relationship is unique (e.g. one-to-one relationships)
+   */
+  $unique: boolean = false;
 
   /**
    * Creates a new relationship definition
@@ -273,6 +332,34 @@ export class RelationDef<
   single(): RelationDef<To, TRequired, false, TDefault> {
     this.$array = false as any;
     return this as any;
+  }
+
+  /**
+   * Creates an index for this relationship.
+   * @param name The index name.
+   * @returns `this`.
+   */
+  index(name: string): this {
+    this.$indexName = name;
+    return this;
+  }
+
+  /**
+   * Sets the relationship as unique.
+   * @returns `this`.
+   */
+  unique(): this {
+    this.$unique = true;
+    return this;
+  }
+
+  /**
+   * Sets the relationship as not unique.
+   * @returns `this`.
+   */
+  common(): this {
+    this.$unique = false;
+    return this;
   }
 }
 

--- a/packages/kineo/src/schema/field.ts
+++ b/packages/kineo/src/schema/field.ts
@@ -1,3 +1,5 @@
+import type { StandardSchemaV1 } from "./standard-schema";
+
 /**
  * All supported field types.
  */
@@ -5,6 +7,7 @@ export type Kind =
   | "string"
   | "char"
   | "int"
+  | "bigint"
   | "float"
   | "date"
   | "time"
@@ -47,6 +50,10 @@ export class FieldDef<
    * If this field is unique.
    */
   $unique = false;
+  /**
+   * Standard Schema validator for the field.
+   */
+  $schema?: StandardSchemaV1;
 
   /**
    * Creates a new field definition
@@ -160,6 +167,15 @@ export class FieldDef<
     this.$unique = false;
     return this;
   }
+
+  /**
+   * Adds a Standard Schema validator.
+   * @returns `this`.
+   */
+  validate(schema: StandardSchemaV1): this {
+    this.$schema = schema;
+    return this;
+  }
 }
 
 /**
@@ -204,6 +220,10 @@ export class RelationDef<
    * If this relationship is unique (e.g. one-to-one relationships)
    */
   $unique: boolean = false;
+  /**
+   * Standard Schema validator.
+   */
+  $schema?: StandardSchemaV1;
 
   /**
    * Creates a new relationship definition
@@ -361,6 +381,15 @@ export class RelationDef<
     this.$unique = false;
     return this;
   }
+
+  /**
+   * Adds a Standard Schema validator.
+   * @returns `this`.
+   */
+  validate(schema: StandardSchemaV1): this {
+    this.$schema = schema;
+    return this;
+  }
 }
 
 /**
@@ -385,6 +414,12 @@ export const field = {
    * @returns A int field definition.
    */
   int: (name?: string) => new FieldDef("int", name),
+  /**
+   * Creates a new `bigint` field definition.
+   * @param name _optional_ The name of the field.
+   * @returns A int field definition.
+   */
+  bigint: (name?: string) => new FieldDef("bigint", name),
   /**
    * Creates a new floating point field definition.
    * @param name _optional_ The name of the field.

--- a/packages/kineo/src/schema/model.ts
+++ b/packages/kineo/src/schema/model.ts
@@ -1,4 +1,5 @@
 import { FieldDef, RelationDef, type Kind } from "./field";
+import type { StandardSchemaV1 } from "./standard-schema";
 import type { Schema } from ".";
 
 /**
@@ -18,6 +19,10 @@ export class ModelDef<S extends ModelShape> {
    * The indexed fields.
    */
   $indexes = new Map<string, IndexOptions<S>>();
+  /**
+   * The validators for properties.
+   */
+  $schemas = new Map<string, StandardSchemaV1>();
 
   /**
    * Creates a new model definition.
@@ -51,13 +56,27 @@ export class ModelDef<S extends ModelShape> {
   }
 
   /**
-   * Updates indexes, by adding individual field indexes to this model's index map.
+   * Adds validators to properties.
+   * @param props The properties to validate.
+   */
+  validate(props: { [Key in keyof S]: StandardSchemaV1 }) {
+    for (const key in props) {
+      this.$schemas.set(key, props[key]);
+    }
+  }
+
+  /**
+   * Updates indexes and validators, by adding individual field indexes/schemas to this model's index/schema map respectively.
    */
   update() {
     for (const key in this.$shape) {
       const property = this.$shape[key];
       if (property.$indexName && !this.$indexes.has(property.$indexName)) {
         this.$indexes.set(property.$indexName, { fields: [key] });
+      }
+
+      if (property.$schema) {
+        this.$schemas.set(key, property.$schema);
       }
     }
   }
@@ -103,15 +122,17 @@ export type InferField<TField extends FieldDef<any, any, any, any, any>> =
  */
 export type TypeOf<K extends Kind> = K extends "string" | "char"
   ? string
-  : K extends "int" | "float"
-    ? number
-    : K extends "date" | "time" | "datetime" | "timestamp"
-      ? Date
-      : K extends "bool"
-        ? boolean
-        : K extends "blob"
-          ? Blob
-          : never;
+  : K extends "bigint"
+    ? bigint
+    : K extends "int" | "float"
+      ? number
+      : K extends "date" | "time" | "datetime" | "timestamp"
+        ? Date
+        : K extends "bool"
+          ? boolean
+          : K extends "blob"
+            ? Blob
+            : never;
 
 /**
  * Infer a single model's properties.

--- a/packages/kineo/src/schema/model.ts
+++ b/packages/kineo/src/schema/model.ts
@@ -15,7 +15,12 @@ export interface ModelShape {
  */
 export class ModelDef<S extends ModelShape> {
   /**
-   * Creates a new model def
+   * The indexed fields.
+   */
+  $indexes = new Map<string, IndexOptions<S>>();
+
+  /**
+   * Creates a new model definition.
    * @param $shape The model shape.
    * @param $name The internal model name.
    */
@@ -33,6 +38,40 @@ export class ModelDef<S extends ModelShape> {
     this.$name = name;
     return this;
   }
+
+  // TODO timestamping
+
+  /**
+   * Creates an index on fields.
+   * @param name The index name.
+   * @param opts The index options.
+   */
+  index(name: string, opts: IndexOptions<S>) {
+    this.$indexes.set(name, opts);
+  }
+
+  /**
+   * Updates indexes, by adding individual field indexes to this model's index map.
+   */
+  update() {
+    for (const key in this.$shape) {
+      const property = this.$shape[key];
+      if (property.$indexName && !this.$indexes.has(property.$indexName)) {
+        this.$indexes.set(property.$indexName, { fields: [key] });
+      }
+    }
+  }
+}
+
+export interface IndexOptions<S extends ModelShape> {
+  fields: (keyof S)[];
+  where?: {
+    [Key in keyof S]: S[Key] extends FieldDef<any, any, any, any, any>
+      ? InferField<S[Key]>
+      : S[Key] extends RelationDef<any, any, any, any>
+        ? InferRelationship<S[Key], any>
+        : never;
+  };
 }
 
 /**

--- a/packages/kineo/src/schema/standard-schema.ts
+++ b/packages/kineo/src/schema/standard-schema.ts
@@ -1,0 +1,78 @@
+/* eslint-disable -- https://standardschema.dev/ */
+
+/** The Standard Schema interface. */
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
+  /** The Standard Schema properties. */
+  readonly "~standard": StandardSchemaV1.Props<Input, Output>;
+}
+
+export declare namespace StandardSchemaV1 {
+  /** The Standard Schema properties interface. */
+  export interface Props<Input = unknown, Output = Input> {
+    /** The version number of the standard. */
+    readonly version: 1;
+    /** The vendor name of the schema library. */
+    readonly vendor: string;
+    /** Validates unknown input values. */
+    readonly validate: (
+      value: unknown,
+      options?: StandardSchemaV1.Options | undefined,
+    ) => Result<Output> | Promise<Result<Output>>;
+    /** Inferred types associated with the schema. */
+    readonly types?: Types<Input, Output> | undefined;
+  }
+
+  /** The result interface of the validate function. */
+  export type Result<Output> = SuccessResult<Output> | FailureResult;
+
+  /** The result interface if validation succeeds. */
+  export interface SuccessResult<Output> {
+    /** The typed output value. */
+    readonly value: Output;
+    /** A falsy value for `issues` indicates success. */
+    readonly issues?: undefined;
+  }
+
+  export interface Options {
+    /** Explicit support for additional vendor-specific parameters, if needed. */
+    readonly libraryOptions?: Record<string, unknown> | undefined;
+  }
+
+  /** The result interface if validation fails. */
+  export interface FailureResult {
+    /** The issues of failed validation. */
+    readonly issues: ReadonlyArray<Issue>;
+  }
+
+  /** The issue interface of the failure output. */
+  export interface Issue {
+    /** The error message of the issue. */
+    readonly message: string;
+    /** The path of the issue, if any. */
+    readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined;
+  }
+
+  /** The path segment interface of the issue. */
+  export interface PathSegment {
+    /** The key representing a path segment. */
+    readonly key: PropertyKey;
+  }
+
+  /** The Standard Schema types interface. */
+  export interface Types<Input = unknown, Output = Input> {
+    /** The input type of the schema. */
+    readonly input: Input;
+    /** The output type of the schema. */
+    readonly output: Output;
+  }
+
+  /** Infers the input type of a Standard Schema. */
+  export type InferInput<Schema extends StandardSchemaV1> = NonNullable<
+    Schema["~standard"]["types"]
+  >["input"];
+
+  /** Infers the output type of a Standard Schema. */
+  export type InferOutput<Schema extends StandardSchemaV1> = NonNullable<
+    Schema["~standard"]["types"]
+  >["output"];
+}

--- a/packages/kineo/tests/model.test.ts
+++ b/packages/kineo/tests/model.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach, vi } from "vitest";
 import { Model, GraphModel } from "@/model";
+import { ModelDef } from "@/schema";
 
 // ---------- Mock IR emitter ---------- //
 vi.mock("@/ir", () => ({
@@ -155,7 +156,7 @@ describe("Model (with fake adapter)", () => {
       { id: 1, name: "Alice" },
       { id: 2, name: "Bob" },
     ];
-    model = new Model("User", adapter);
+    model = new Model(new ModelDef({}, "User"), "User", adapter);
   });
 
   test("findFirst returns first record", async () => {
@@ -239,7 +240,7 @@ describe("GraphModel (with fake adapter)", () => {
       { id: 1, name: "Root" },
       { id: 2, name: "Child" },
     ];
-    graph = new GraphModel("User", adapter);
+    graph = new GraphModel(new ModelDef({}, "User"), "User", adapter);
   });
 
   test("findPath returns nodes and edges", async () => {

--- a/packages/kineokit/package.json
+++ b/packages/kineokit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kineokit",
   "type": "module",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Migration manager for Kineo.",
   "bin": {
     "kineokit": "./dist/main.mjs",

--- a/packages/kineokit/src/adapter.ts
+++ b/packages/kineokit/src/adapter.ts
@@ -11,6 +11,13 @@ type Resolvable<T> = T | Promise<T>;
  */
 export interface AdapterKit {
   /**
+   * Executes a one-off command.
+   * @param command The command to execute.
+   * @param params Parameters of the command.
+   */
+  exec(command: string, params: Record<string, unknown>): Resolvable<any>;
+
+  /**
    * Push a schema to the database. You don't need to warn the user, Kineo does that for you.
    * @param schema The schema to push.
    */

--- a/packages/kineokit/src/adapters/neo4j.ts
+++ b/packages/kineokit/src/adapters/neo4j.ts
@@ -42,6 +42,10 @@ export const neo4jKit = defineAdapterKit<
     driver,
     session,
 
+    async exec(command, params) {
+      await session.run(command, params);
+    },
+
     async pull() {
       const models: Schema = {};
 
@@ -98,126 +102,6 @@ export const neo4jKit = defineAdapterKit<
       };
     },
 
-    async push(schema: Schema) {
-      // Wrap everything so one exception doesn't stop the rest
-      async function tryRun(cypher: string) {
-        try {
-          await session.run(cypher);
-        } catch (err: any) {
-          // Neo4j will error with "already exists" -> ignore
-          console.warn(
-            "[kineo/neo4j] Skipped:",
-            cypher,
-            "Reason:",
-            err.code || err.message,
-          );
-        }
-      }
-
-      // Convert schema key or $modelName to label
-      function getLabel(name: string, model: ModelDef<any>): string {
-        return model.$name ?? name;
-      }
-
-      /**
-       * For each model -> produce constraints & indexes
-       */
-      for (const [modelKey, modelDef] of Object.entries(schema)) {
-        const label = getLabel(modelKey, modelDef);
-
-        const fieldEntries = Object.entries(modelDef).filter(
-          ([k, v]) => k !== "$modelName" && v instanceof FieldDef,
-        ) as [string, FieldDef<any, any, any, any>][];
-
-        const relationEntries = Object.entries(modelDef).filter(
-          ([k, v]) => k !== "$modelName" && v instanceof RelationDef,
-        ) as [string, RelationDef<any, any, any, any>][];
-
-        // ------------------------------------------------------------
-        // 1. FIELD-BASED NODE CONSTRAINTS
-        // ------------------------------------------------------------
-
-        for (const [propName, field] of fieldEntries) {
-          const neoProp = field.$name ?? propName;
-
-          // 1a. ID -> unique constraint
-          if (field.$id) {
-            const cypher = `
-          CREATE CONSTRAINT ${label}_${neoProp}_unique
-          IF NOT EXISTS
-          FOR (n:${label})
-          REQUIRE n.${neoProp} IS UNIQUE
-        `;
-            await tryRun(cypher);
-          }
-
-          // 1b. Required -> existence constraint
-          if (field.$required) {
-            const cypher = `
-          CREATE CONSTRAINT ${label}_${neoProp}_exists
-          IF NOT EXISTS
-          FOR (n:${label})
-          REQUIRE n.${neoProp} IS NOT NULL
-        `;
-            await tryRun(cypher);
-          }
-
-          // 1c. Optional index (useful for search)
-          if (!field.$id) {
-            const cypher = `
-          CREATE INDEX ${label}_${neoProp}_index
-          IF NOT EXISTS
-          FOR (n:${label})
-          ON (n.${neoProp})
-        `;
-            await tryRun(cypher);
-          }
-        }
-
-        // ------------------------------------------------------------
-        // 2. RELATIONSHIP CONSTRAINTS
-        // ------------------------------------------------------------
-
-        for (const [relName, rel] of relationEntries) {
-          const relLabel = rel.$label ?? relName;
-
-          // Directions:
-          // outgoing: (a)-[:REL]->(b)
-          // incoming: (a)<-[:REL]-(b)
-          // both:     (a)-[:REL]-(b)
-          const direction = rel.$direction;
-
-          // Required relationship existence constraint
-          if (rel.$required) {
-            // For required rels we at least enforce presence of the relationship.
-            // Neo4j supports relationship property constraints, but required relationships
-            // must be enforced through pattern constraints (Neo4j 5+):
-            //
-            //   FOR (a:Label) REQUIRE (a)-[:REL]->() IS NOT EMPTY
-            //
-            let pattern = "";
-            if (direction === "outgoing") {
-              pattern = `(a:${label})-[:${relLabel}]->()`;
-            } else if (direction === "incoming") {
-              pattern = `(a:${label})<-[:${relLabel}]-()`;
-            } else {
-              pattern = `(a:${label})-[:${relLabel}]-()`;
-            }
-
-            const cypher = `
-          CREATE CONSTRAINT ${label}_${relLabel}_rel_required
-          IF NOT EXISTS
-          FOR (a:${label})
-          REQUIRE ${pattern} IS NOT EMPTY
-        `;
-            await tryRun(cypher);
-          }
-        }
-      }
-
-      console.log("[kineo/neo4j] Schema push completed.");
-    },
-
     async deploy(migration, hash) {
       await session.run(migration);
 
@@ -254,26 +138,17 @@ export const neo4jKit = defineAdapterKit<
       return deployed ? "completed" : "pending";
     },
 
-    generate(prev, cur) {
+    generate(
+      prev /*: Record<string, ModelDef<any>>*/,
+      cur /*: Record<string, ModelDef<any>>*/,
+    ) {
       const migrations: MigrationEntry[] = [];
 
       const prevModels = new Set(Object.keys(prev || {}));
       const curModels = new Set(Object.keys(cur || {}));
 
-      function findIdFieldName(modelDef: ModelDef<any>): string | undefined {
-        for (const k of Object.keys(modelDef)) {
-          const v = (modelDef as any)[k];
-          if (isFieldDef(v)) {
-            if ((v as FieldDef<any, any, any, any>).$id) {
-              return (v as FieldDef<any, any, any, any>).$name || k;
-            }
-          }
-        }
-        return undefined;
-      }
-
       // ---------- New models ----------
-      for (const m of Object.keys(cur)) {
+      for (const m in cur) {
         if (!prevModels.has(m)) {
           const def = cur[m];
           const label = modelLabel(m, def);
@@ -310,14 +185,14 @@ export const neo4jKit = defineAdapterKit<
               command:
                 `DROP CONSTRAINT IF EXISTS FOR (n:${label}) REQUIRE n.${idProp} IS UNIQUE;\n` +
                 `MATCH (n:${label}) DETACH DELETE n;`,
-              reverse: "", // cannot bring deleted nodes back
+              reverse: "",
             });
           } else {
             migrations.push({
               type: "command",
               description: `Delete nodes for removed model ${label}`,
               command: `MATCH (n:${label}) DETACH DELETE n;`,
-              reverse: "", // irreversible
+              reverse: "",
             });
           }
         }
@@ -331,20 +206,16 @@ export const neo4jKit = defineAdapterKit<
         const curDef = cur[m];
         const label = modelLabel(m, curDef);
 
-        const prevKeys = new Set(
-          Object.keys(prevDef.$shape || {}).filter((k) => k !== "$modelName"),
-        );
-        const curKeys = new Set(
-          Object.keys(curDef.$shape || {}).filter((k) => k !== "$modelName"),
-        );
+        const prevKeys = new Set(Object.keys(prevDef.$shape));
+        const curKeys = new Set(Object.keys(curDef.$shape));
 
         // ---------- Added keys ----------
-        for (const key of Array.from(curKeys)) {
+        for (const key of curKeys) {
           if (!prevKeys.has(key)) {
             const val = curDef.$shape[key];
 
             if (isFieldDef(val)) {
-              const fieldDef = val as FieldDef<any, any, any, any>;
+              const fieldDef = val;
               const propName = fieldDef.$name || key;
 
               if (fieldDef.$default !== undefined) {
@@ -354,165 +225,130 @@ export const neo4jKit = defineAdapterKit<
                   command: `MATCH (n:${label}) WHERE n.${propName} IS NULL OR NOT exists(n.${propName}) SET n.${propName} = ${serializeDefault(fieldDef.$default)};`,
                   reverse: `MATCH (n:${label}) REMOVE n.${propName};`,
                 });
-              } else {
+              }
+
+              // ---- UNIQUE ----
+              if (fieldDef.$id || fieldDef.$unique) {
                 migrations.push({
-                  type: "note",
-                  description: `Field ${propName} added to ${label}`,
-                  note: `Field '${propName}' added with no default; existing nodes unchanged.`,
+                  type: "command",
+                  description: `Create uniqueness constraint for ${propName} on ${label}`,
+                  command: `CREATE CONSTRAINT ${uniqueConstraintName(label, propName, fieldDef.$indexName)} IF NOT EXISTS FOR (n:${label}) REQUIRE n.${propName} IS UNIQUE;`,
+                  reverse: `DROP CONSTRAINT ${uniqueConstraintName(label, propName, fieldDef.$indexName)} IF EXISTS;`,
                 });
               }
 
-              if (fieldDef.$id) {
+              // ---- INDEX ----
+              if (fieldDef.$indexName && !fieldDef.$unique && !fieldDef.$id) {
                 migrations.push({
                   type: "command",
-                  description: `Create uniqueness constraint for newly-added id field ${propName} on ${label}`,
-                  command: `CREATE CONSTRAINT IF NOT EXISTS FOR (n:${label}) REQUIRE n.${propName} IS UNIQUE;`,
-                  reverse: `DROP CONSTRAINT IF EXISTS FOR (n:${label}) REQUIRE n.${propName} IS UNIQUE;`,
+                  description: `Create index for ${propName} on ${label}`,
+                  command: `CREATE INDEX ${indexName(label, propName, fieldDef.$indexName)} IF NOT EXISTS FOR (n:${label}) ON (n.${propName});`,
+                  reverse: `DROP INDEX ${indexName(label, propName, fieldDef.$indexName)} IF EXISTS;`,
                 });
               }
             } else if (isRelationDef(val)) {
-              const rel = val as RelationDef<any, any, any, any>;
-              migrations.push({
-                type: "note",
-                description: `Relation ${key} added on ${label}`,
-                note: `Relation '${key}' added on '${label}' pointing to '${rel.$to}'.`,
-              });
-            } else {
-              migrations.push({
-                type: "note",
-                description: `Unknown key ${String(key)} added`,
-                note: `Key '${String(key)}' added but not recognized.`,
-              });
-            }
-          }
-        }
+              const rel = val;
+              const relLabel = rel.$label || key;
 
-        // ---------- Removed keys ----------
-        for (const key of Array.from(prevKeys)) {
-          if (!curKeys.has(key)) {
-            const val = prevDef.$shape[key];
-
-            if (isFieldDef(val)) {
-              const fieldDef = val as FieldDef<any, any, any, any>;
-              const propName = fieldDef.$name || key;
-
-              migrations.push({
-                type: "command",
-                description: `Remove property for removed field ${propName} on ${label}`,
-                command: `MATCH (n:${label}) REMOVE n.${propName};`,
-                reverse: "", // cannot restore old values
-              });
-
-              if (fieldDef.$id) {
+              // ---- RELATION UNIQUE ----
+              if (rel.$unique) {
                 migrations.push({
                   type: "command",
-                  description: `Drop uniqueness constraint for removed id field ${propName}`,
-                  command: `DROP CONSTRAINT IF EXISTS FOR (n:${label}) REQUIRE n.${propName} IS UNIQUE;`,
-                  reverse: `CREATE CONSTRAINT IF NOT EXISTS FOR (n:${label}) REQUIRE n.${propName} IS UNIQUE;`,
+                  description: `Create unique relationship constraint for ${relLabel}`,
+                  command: `CREATE CONSTRAINT ${uniqueConstraintName(relLabel, "rel", rel.$indexName)} IF NOT EXISTS FOR ()-[r:${relLabel}]-() REQUIRE r IS UNIQUE;`,
+                  reverse: `DROP CONSTRAINT ${uniqueConstraintName(relLabel, "rel", rel.$indexName)} IF EXISTS;`,
                 });
               }
-            } else if (isRelationDef(val)) {
-              migrations.push({
-                type: "note",
-                description: `Relation ${key} removed from ${label}`,
-                note: `Relation '${key}' removed; relationship data not automatically deleted.`,
-              });
-            } else {
-              migrations.push({
-                type: "note",
-                description: `Unknown key ${String(key)} removed`,
-                note: `Key '${String(key)}' removed from '${label}'.`,
-              });
+
+              // ---- RELATION INDEX ----
+              if (rel.$indexName && !rel.$unique) {
+                migrations.push({
+                  type: "command",
+                  description: `Create relationship index for ${relLabel}`,
+                  command: `CREATE INDEX ${indexName(relLabel, "rel", rel.$indexName)} IF NOT EXISTS FOR ()-[r:${relLabel}]-() ON (r);`,
+                  reverse: `DROP INDEX ${indexName(relLabel, "rel", rel.$indexName)} IF EXISTS;`,
+                });
+              }
             }
           }
         }
 
         // ---------- Modified keys ----------
-        for (const key of Array.from(curKeys)) {
+        for (const key of curKeys) {
           if (!prevKeys.has(key)) continue;
 
-          const prevVal = prevDef.$shape[key];
-          const curVal = curDef.$shape[key];
+          const p = prevDef.$shape[key];
+          const c = curDef.$shape[key];
 
-          if (isFieldDef(prevVal) && isFieldDef(curVal)) {
-            const p = prevVal as FieldDef<any, any, any, any>;
-            const c = curVal as FieldDef<any, any, any, any>;
+          // ---------- FIELD ----------
+          if (isFieldDef(p) && isFieldDef(c)) {
             const propName = c.$name || key;
 
-            if (p.$default !== c.$default) {
-              if (c.$default !== undefined) {
-                migrations.push({
-                  type: "command",
-                  description: `Apply new default for ${propName} on ${label}`,
-                  command: `MATCH (n:${label}) WHERE n.${propName} IS NULL OR NOT exists(n.${propName}) SET n.${propName} = ${serializeDefault(c.$default)};`,
-                  reverse:
-                    p.$default !== undefined
-                      ? `MATCH (n:${label}) WHERE n.${propName} = ${serializeDefault(c.$default)} SET n.${propName} = ${serializeDefault(p.$default)};`
-                      : `MATCH (n:${label}) REMOVE n.${propName};`,
-                });
-              } else {
-                migrations.push({
-                  type: "note",
-                  description: `Default removed for ${propName} on ${label}`,
-                  note: `Default removed; no data change.`,
-                });
-              }
-            }
+            const prevUnique = !!p.$id || !!p.$unique;
+            const curUnique = !!c.$id || !!c.$unique;
 
-            if (!p.$id && c.$id) {
+            // ---- UNIQUE CHANGED ----
+            if (!prevUnique && curUnique) {
               migrations.push({
                 type: "command",
                 description: `Create uniqueness constraint for ${propName}`,
-                command: `CREATE CONSTRAINT IF NOT EXISTS FOR (n:${label}) REQUIRE n.${propName} IS UNIQUE;`,
-                reverse: `DROP CONSTRAINT IF EXISTS FOR (n:${label}) REQUIRE n.${propName} IS UNIQUE;`,
+                command: `CREATE CONSTRAINT ${uniqueConstraintName(label, propName, c.$indexName)} IF NOT EXISTS FOR (n:${label}) REQUIRE n.${propName} IS UNIQUE;`,
+                reverse: `DROP CONSTRAINT ${uniqueConstraintName(label, propName, c.$indexName)} IF EXISTS;`,
               });
             }
 
-            if (p.$id && !c.$id) {
+            if (prevUnique && !curUnique) {
               migrations.push({
                 type: "command",
                 description: `Drop uniqueness constraint for ${propName}`,
-                command: `DROP CONSTRAINT IF EXISTS FOR (n:${label}) REQUIRE n.${propName} IS UNIQUE;`,
-                reverse: `CREATE CONSTRAINT IF NOT EXISTS FOR (n:${label}) REQUIRE n.${propName} IS UNIQUE;`,
+                command: `DROP CONSTRAINT ${uniqueConstraintName(label, propName, p.$indexName)} IF EXISTS;`,
+                reverse: `CREATE CONSTRAINT ${uniqueConstraintName(label, propName, p.$indexName)} IF NOT EXISTS FOR (n:${label}) REQUIRE n.${propName} IS UNIQUE;`,
               });
             }
 
-            if (p.$kind !== c.$kind) {
-              migrations.push({
-                type: "note",
-                description: `Type changed for ${propName}`,
-                note: `Type changed from '${p.$kind}' to '${c.$kind}'.`,
-              });
-            }
+            // ---- INDEX NAME CHANGED ----
+            if (p.$indexName !== c.$indexName && !curUnique) {
+              if (p.$indexName) {
+                migrations.push({
+                  type: "command",
+                  description: `Drop index for ${propName}`,
+                  command: `DROP INDEX ${indexName(label, propName, p.$indexName)} IF EXISTS;`,
+                  reverse: "",
+                });
+              }
 
-            if (p.$array !== c.$array) {
-              migrations.push({
-                type: "note",
-                description: `Array flag changed for ${propName}`,
-                note: `Array-ness changed; may require custom migration.`,
-              });
+              if (c.$indexName) {
+                migrations.push({
+                  type: "command",
+                  description: `Create index for ${propName}`,
+                  command: `CREATE INDEX ${indexName(label, propName, c.$indexName)} IF NOT EXISTS FOR (n:${label}) ON (n.${propName});`,
+                  reverse: `DROP INDEX ${indexName(label, propName, c.$indexName)} IF EXISTS;`,
+                });
+              }
             }
-          } else if (isRelationDef(prevVal) && isRelationDef(curVal)) {
-            const p = prevVal;
-            const c = curVal;
+          }
 
-            if (
-              p.$to !== c.$to ||
-              p.$label !== c.$label ||
-              p.$direction !== c.$direction
-            ) {
-              migrations.push({
-                type: "note",
-                description: `Relation changed for '${key}'`,
-                note: `Relation '${key}' changed; cannot auto-migrate data.`,
-              });
+          // ---------- RELATION ----------
+          else if (isRelationDef(p) && isRelationDef(c)) {
+            const relLabel = c.$label || key;
+
+            if (p.$unique !== c.$unique) {
+              if (c.$unique) {
+                migrations.push({
+                  type: "command",
+                  description: `Create unique constraint for relationship ${relLabel}`,
+                  command: `CREATE CONSTRAINT ${uniqueConstraintName(relLabel, "rel", c.$indexName)} IF NOT EXISTS FOR ()-[r:${relLabel}]-() REQUIRE r IS UNIQUE;`,
+                  reverse: `DROP CONSTRAINT ${uniqueConstraintName(relLabel, "rel", c.$indexName)} IF EXISTS;`,
+                });
+              } else {
+                migrations.push({
+                  type: "command",
+                  description: `Drop unique constraint for relationship ${relLabel}`,
+                  command: `DROP CONSTRAINT ${uniqueConstraintName(relLabel, "rel", p.$indexName)} IF EXISTS;`,
+                  reverse: "",
+                });
+              }
             }
-          } else {
-            migrations.push({
-              type: "note",
-              description: `Key ${key} changed type`,
-              note: `Field <-> relation change; no automatic migration.`,
-            });
           }
         }
       }
@@ -572,11 +408,23 @@ function inferKind(value: any): FieldDef<any, any, any, any> {
   return field.string(); // fallback
 }
 
+function findIdFieldName(modelDef: ModelDef<any>) {
+  for (const k in modelDef.$shape) {
+    const v = modelDef.$shape[k];
+    if (isFieldDef(v)) {
+      if (v.$id) {
+        return v.$name ?? k;
+      }
+    }
+  }
+  return null;
+}
+
 /**
- * Produce a stable label for a model: prefer $modelName when set, otherwise use schema key.
+ * Produce a stable label for a model: prefer def.$name when set, otherwise use schema key.
  */
-function modelLabel(key: string, def: any) {
-  return (def && typeof def.$modelName === "string" && def.$modelName) || key;
+function modelLabel(key: string, def?: ModelDef<any>) {
+  return def && typeof def.$name === "string" ? def.$name : key;
 }
 
 function isFieldDef(v: any): v is FieldDef<any, any, any, any> {
@@ -646,4 +494,12 @@ function mergeRelationship(
       rel.both(relType);
     }
   }
+}
+
+function uniqueConstraintName(label: string, prop: string, name?: string) {
+  return name || `${label}_${prop}_unique`;
+}
+
+function indexName(label: string, prop: string, name?: string) {
+  return name || `${label}_${prop}_idx`;
 }

--- a/packages/kineokit/src/kit.ts
+++ b/packages/kineokit/src/kit.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import type { AdapterKit } from "./adapter";
 import { FieldDef, RelationDef, type Schema } from "kineo/schema";
 import { KineoKitError, KineoKitErrorKind } from "./error";
+import { toMigration } from "./migration";
 
 /**
  * Pushes a schema to the database.
@@ -15,11 +16,10 @@ export async function push(
   newSchema: Schema,
   force?: boolean,
 ) {
-  if (!adapter.pull) throw new KineoKitError(KineoKitErrorKind.NoSupport);
-  if (!adapter.push) throw new KineoKitError(KineoKitErrorKind.NoSupport);
-
+  let prevSchema: Schema | undefined;
   if (!force) {
-    const { schema: prevSchema } = await adapter.pull();
+    if (!adapter.pull) throw new KineoKitError(KineoKitErrorKind.NoSupport);
+    ({ schema: prevSchema } = await adapter.pull());
     const diff = getDiff(prevSchema, newSchema);
 
     if (diff.breaking.length > 0) {
@@ -27,7 +27,21 @@ export async function push(
     }
   }
 
-  await adapter.push(newSchema);
+  if (adapter.push) {
+    await adapter.push(newSchema);
+  } else {
+    if (!adapter.generate) throw new KineoKitError(KineoKitErrorKind.NoSupport);
+    if (!adapter.deploy) throw new KineoKitError(KineoKitErrorKind.NoSupport);
+
+    if (!prevSchema) {
+      if (!adapter.pull) throw new KineoKitError(KineoKitErrorKind.NoSupport);
+      ({ schema: prevSchema } = await adapter.pull());
+    }
+
+    const entries = await adapter.generate(prevSchema, newSchema);
+    const [up] = toMigration(entries);
+    await adapter.exec(up, {});
+  }
 }
 
 /**

--- a/packages/kineokit/tests/adapters/neo4j.test.ts
+++ b/packages/kineokit/tests/adapters/neo4j.test.ts
@@ -50,21 +50,6 @@ describe("neo4jAdapterKit (integration)", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // push()
-  // ---------------------------------------------------------------------------
-
-  test("push() applies constraints & indexes without throwing", async () => {
-    const schema = defineSchema({
-      User: model("User", {
-        id: field.string().id().required(),
-        name: field.string().required(),
-      }),
-    });
-
-    await expect(adapter.push!(schema)).resolves.not.toThrow();
-  });
-
-  // ---------------------------------------------------------------------------
   // generate()
   // ---------------------------------------------------------------------------
 

--- a/packages/kineokit/tests/config.test.ts
+++ b/packages/kineokit/tests/config.test.ts
@@ -27,7 +27,9 @@ function mockAdapter(): Adapter<typeof GraphModel, any> {
 }
 
 function mockAdapterKit(): AdapterKit {
-  return {};
+  return {
+    exec() {},
+  };
 }
 
 describe("parseConfig()", () => {

--- a/packages/kineokit/tests/kit.test.ts
+++ b/packages/kineokit/tests/kit.test.ts
@@ -13,7 +13,7 @@ const simpleSchema = defineSchema({
 
 describe("push()", () => {
   test("throws if adapter lacks pull or push", async () => {
-    const adapter: AdapterKit = {};
+    const adapter: AdapterKit = { exec() {} };
     await expect(push(adapter, simpleSchema)).rejects.toThrowError(
       KineoKitError,
     );
@@ -21,6 +21,7 @@ describe("push()", () => {
 
   test("throws on breaking schema diff", async () => {
     const adapter: AdapterKit = {
+      exec() {},
       pull: vi.fn().mockResolvedValue({
         schema: {
           User: model({
@@ -46,6 +47,7 @@ describe("push()", () => {
 
   test("calls push when no breaking changes", async () => {
     const adapter: AdapterKit = {
+      exec() {},
       pull: vi.fn().mockResolvedValue({ schema: simpleSchema, full: true }),
       push: vi.fn(),
     };
@@ -56,6 +58,7 @@ describe("push()", () => {
 
   test("skips diff check when force = true", async () => {
     const adapter: AdapterKit = {
+      exec() {},
       pull: vi.fn().mockRejectedValue(new Error("should not be called")),
       push: vi.fn(),
     };
@@ -87,12 +90,13 @@ describe("getDiff()", () => {
 
 describe("pull()", () => {
   test("throws if adapter lacks pull", async () => {
-    const adapter: AdapterKit = {};
+    const adapter: AdapterKit = { exec() {} };
     await expect(pull(adapter)).rejects.toThrowError(KineoKitError);
   });
 
   test("returns schema if adapter.pull exists", async () => {
     const adapter: AdapterKit = {
+      exec() {},
       pull: vi.fn().mockResolvedValue({ schema: simpleSchema, full: true }),
     };
 
@@ -104,7 +108,7 @@ describe("pull()", () => {
 
 describe("generate()", () => {
   test("throws if adapter lacks generate", async () => {
-    const adapter: AdapterKit = {};
+    const adapter: AdapterKit = { exec() {} };
     await expect(generate(adapter, simpleSchema, simpleSchema)).rejects.toThrow(
       KineoKitError,
     );
@@ -112,6 +116,7 @@ describe("generate()", () => {
 
   test("calls adapter.generate()", async () => {
     const adapter: AdapterKit = {
+      exec() {},
       generate: vi.fn().mockResolvedValue(["migration.sql"]),
     };
     const result = await generate(adapter, simpleSchema, simpleSchema);
@@ -122,12 +127,13 @@ describe("generate()", () => {
 
 describe("deploy()", () => {
   test("throws if adapter lacks deploy", async () => {
-    const adapter: AdapterKit = {};
+    const adapter: AdapterKit = { exec() {} };
     await expect(deploy(adapter, "")).rejects.toThrow(KineoKitError);
   });
 
   test("calls deploy with hash", async () => {
     const adapter: AdapterKit = {
+      exec() {},
       deploy: vi.fn(),
     };
 
@@ -138,12 +144,13 @@ describe("deploy()", () => {
 
 describe("status()", () => {
   test("throws if adapter lacks status", async () => {
-    const adapter: AdapterKit = {};
+    const adapter: AdapterKit = { exec() {} };
     await expect(status(adapter, "")).rejects.toThrow(KineoKitError);
   });
 
   test("calls status with hash", async () => {
     const adapter: AdapterKit = {
+      exec() {},
       status: vi.fn().mockResolvedValue("completed"),
     };
 

--- a/packages/kineokit/tests/migrations.test.ts
+++ b/packages/kineokit/tests/migrations.test.ts
@@ -103,10 +103,10 @@ describe("deemitEntries()", () => {
       },
     ];
 
-    const emitd = toMigration(entries);
-    const deemitd = toEntries(emitd);
+    const migration = toMigration(entries);
+    const decompiledEntries = toEntries(migration);
 
-    expect(deemitd).toEqual(
+    expect(decompiledEntries).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           type: "command",


### PR DESCRIPTION
this:
- adds `.index()` on fields, relations and models;
- adds `.unique()` on fields and relations;
- makes `betterAuthSchema` a function you can pass plugins to;
- makes `push` not required to be a separate step